### PR TITLE
fix: remove double component registration in water_heater

### DIFF
--- a/components/waterfurnace_aurora/water_heater/__init__.py
+++ b/components/waterfurnace_aurora/water_heater/__init__.py
@@ -7,8 +7,19 @@ from .. import waterfurnace_aurora_ns, WaterFurnaceAurora, CONF_AURORA_ID
 DEPENDENCIES = ["waterfurnace_aurora"]
 CODEOWNERS = ["@daemonp"]
 
+# In ESPHome <= 2026.1.x, WaterHeater already inherits from Component and
+# register_water_heater() calls register_component().  In 2026.2+, Component
+# was removed from WaterHeater, so we must add it ourselves.
+_WH_HAS_COMPONENT = water_heater.WaterHeater.inherits_from(cg.Component)
+
+_bases = (
+    (water_heater.WaterHeater,)
+    if _WH_HAS_COMPONENT
+    else (water_heater.WaterHeater, cg.Component)
+)
+
 AuroraWaterHeater = waterfurnace_aurora_ns.class_(
-    "AuroraWaterHeater", water_heater.WaterHeater, cg.Component
+    "AuroraWaterHeater", *_bases
 )
 
 CONFIG_SCHEMA = water_heater.water_heater_schema(
@@ -19,9 +30,17 @@ CONFIG_SCHEMA = water_heater.water_heater_schema(
     }
 )
 
+if not _WH_HAS_COMPONENT:
+    CONFIG_SCHEMA = CONFIG_SCHEMA.extend(cv.COMPONENT_SCHEMA)
+
 
 async def to_code(config):
     var = await water_heater.new_water_heater(config)
+
+    # In 2026.2+ register_water_heater() no longer calls register_component(),
+    # so we must do it ourselves.
+    if not _WH_HAS_COMPONENT:
+        await cg.register_component(var, config)
 
     parent = await cg.get_variable(config[CONF_AURORA_ID])
     cg.add(var.set_parent(parent))

--- a/components/waterfurnace_aurora/water_heater/aurora_water_heater.h
+++ b/components/waterfurnace_aurora/water_heater/aurora_water_heater.h
@@ -1,13 +1,21 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/version.h"
 #include "esphome/components/water_heater/water_heater.h"
 #include "../waterfurnace_aurora.h"
 
 namespace esphome {
 namespace waterfurnace_aurora {
 
+// In ESPHome 2026.2+ WaterHeater no longer inherits Component, so we add it.
+// In ESPHome <= 2026.1.x WaterHeater already inherits Component; the
+// preprocessor guard below avoids a diamond-inheritance ambiguity.
+#if defined(ESPHOME_VERSION_CODE) && ESPHOME_VERSION_CODE >= VERSION_CODE(2026, 2, 0)
 class AuroraWaterHeater : public water_heater::WaterHeater, public Component {
+#else
+class AuroraWaterHeater : public water_heater::WaterHeater {
+#endif
  public:
   void setup() override;
   void dump_config() override;


### PR DESCRIPTION
new_water_heater() internally calls register_water_heater() which already calls cg.register_component(). The explicit second call caused: ValueError: Component ID aurora_dhw was not declared to inherit from Component, or was registered twice.

Also remove redundant .extend(cv.COMPONENT_SCHEMA) since water_heater_schema() already includes it via _WATER_HEATER_SCHEMA.