### PR TITLE
Polish and shine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,4 @@ esphome/
 home.yaml
 mise.toml
 CODEREVIEW-esphome.md
-a.yaml
+off/

--- a/components/waterfurnace_aurora/binary_sensor/__init__.py
+++ b/components/waterfurnace_aurora/binary_sensor/__init__.py
@@ -62,6 +62,10 @@ BINARY_SENSORS = {
     "diverting_valve": binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_RUNNING,
     ),
+    # Configuration triggers (gap 11)
+    "smartgrid_trigger": binary_sensor.binary_sensor_schema(),
+    "ha_alarm_1_trigger": binary_sensor.binary_sensor_schema(),
+    "ha_alarm_2_trigger": binary_sensor.binary_sensor_schema(),
 }
 
 CONFIG_SCHEMA = cv.Schema(

--- a/components/waterfurnace_aurora/climate/__init__.py
+++ b/components/waterfurnace_aurora/climate/__init__.py
@@ -1,11 +1,20 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import climate
+from esphome.components import climate, sensor, text_sensor
+from esphome.const import (
+    ENTITY_CATEGORY_DIAGNOSTIC,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_PERCENT,
+)
 
 from .. import waterfurnace_aurora_ns, WaterFurnaceAurora, CONF_AURORA_ID, CONF_ZONE, validate_zone
 
 DEPENDENCIES = ["waterfurnace_aurora"]
 CODEOWNERS = ["@daemonp"]
+
+CONF_ZONE_PRIORITY = "zone_priority"
+CONF_ZONE_SIZE = "zone_size"
+CONF_ZONE_NORMALIZED_SIZE = "zone_normalized_size"
 
 AuroraClimate = waterfurnace_aurora_ns.class_(
     "AuroraClimate", climate.Climate, cg.Component
@@ -17,6 +26,18 @@ CONFIG_SCHEMA = (
         {
             cv.GenerateID(CONF_AURORA_ID): cv.use_id(WaterFurnaceAurora),
             cv.Optional(CONF_ZONE, default=1): validate_zone,
+            cv.Optional(CONF_ZONE_PRIORITY): text_sensor.text_sensor_schema(
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_ZONE_SIZE): text_sensor.text_sensor_schema(
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_ZONE_NORMALIZED_SIZE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_PERCENT,
+                accuracy_decimals=0,
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -29,3 +50,12 @@ async def to_code(config):
     parent = await cg.get_variable(config[CONF_AURORA_ID])
     cg.add(var.set_parent(parent))
     cg.add(var.set_zone(config[CONF_ZONE]))
+    if conf := config.get(CONF_ZONE_PRIORITY):
+        sens = await text_sensor.new_text_sensor(conf)
+        cg.add(var.set_zone_priority_sensor(sens))
+    if conf := config.get(CONF_ZONE_SIZE):
+        sens = await text_sensor.new_text_sensor(conf)
+        cg.add(var.set_zone_size_sensor(sens))
+    if conf := config.get(CONF_ZONE_NORMALIZED_SIZE):
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_zone_normalized_size_sensor(sens))

--- a/components/waterfurnace_aurora/climate/aurora_climate.cpp
+++ b/components/waterfurnace_aurora/climate/aurora_climate.cpp
@@ -409,9 +409,9 @@ void AuroraClimate::publish_zone_diagnostics_() {
   // Priority (text: "Comfort" or "Economy")
   if (this->zone_priority_sensor_ != nullptr) {
     const char *priority_str = (zone.priority == ZonePriority::ECONOMY) ? "Economy" : "Comfort";
-    if (this->cached_zone_priority_.empty() || strcmp(this->cached_zone_priority_.c_str(), priority_str) != 0) {
+    if (this->cached_zone_priority_ != priority_str) {
       this->cached_zone_priority_ = priority_str;
-      this->zone_priority_sensor_->publish_state(this->cached_zone_priority_);
+      this->zone_priority_sensor_->publish_state(priority_str);
     }
   }
   
@@ -425,9 +425,9 @@ void AuroraClimate::publish_zone_diagnostics_() {
       case ZoneSize::FULL: size_str = "70"; break;
       default: size_str = "Unknown"; break;
     }
-    if (this->cached_zone_size_.empty() || strcmp(this->cached_zone_size_.c_str(), size_str) != 0) {
+    if (this->cached_zone_size_ != size_str) {
       this->cached_zone_size_ = size_str;
-      this->zone_size_sensor_->publish_state(this->cached_zone_size_);
+      this->zone_size_sensor_->publish_state(size_str);
     }
   }
   

--- a/components/waterfurnace_aurora/climate/aurora_climate.cpp
+++ b/components/waterfurnace_aurora/climate/aurora_climate.cpp
@@ -38,6 +38,9 @@ void AuroraClimate::dump_config() {
     }
   }
   ESP_LOGCONFIG(TAG, "  EMA alpha: %.2f", EMA_ALPHA);
+  if (this->zone_priority_sensor_) ESP_LOGCONFIG(TAG, "  Zone priority sensor: configured");
+  if (this->zone_size_sensor_) ESP_LOGCONFIG(TAG, "  Zone size sensor: configured");
+  if (this->zone_normalized_size_sensor_) ESP_LOGCONFIG(TAG, "  Zone normalized size sensor: configured");
 }
 
 climate::ClimateTraits AuroraClimate::traits() {
@@ -390,7 +393,52 @@ void AuroraClimate::update_state_() {
     }
   }
 
+  // Publish per-zone IZ2 diagnostic sensors
+  if (this->is_iz2_mode_()) {
+    this->publish_zone_diagnostics_();
+  }
+
   this->publish_state_if_changed_();
+}
+
+void AuroraClimate::publish_zone_diagnostics_() {
+  if (this->zone_ > this->parent_->get_num_iz2_zones()) return;
+  
+  const IZ2ZoneData &zone = this->parent_->get_zone_data(this->zone_);
+  
+  // Priority (text: "Comfort" or "Economy")
+  if (this->zone_priority_sensor_ != nullptr) {
+    const char *priority_str = (zone.priority == ZonePriority::ECONOMY) ? "Economy" : "Comfort";
+    if (this->cached_zone_priority_.empty() || strcmp(this->cached_zone_priority_.c_str(), priority_str) != 0) {
+      this->cached_zone_priority_ = priority_str;
+      this->zone_priority_sensor_->publish_state(this->cached_zone_priority_);
+    }
+  }
+  
+  // Size (text: "0", "25", "45", "70" — from Ruby gem ZONE_SIZES)
+  if (this->zone_size_sensor_ != nullptr) {
+    const char *size_str;
+    switch (zone.size) {
+      case ZoneSize::QUARTER: size_str = "0"; break;
+      case ZoneSize::HALF: size_str = "25"; break;
+      case ZoneSize::THREE_QUARTER: size_str = "45"; break;
+      case ZoneSize::FULL: size_str = "70"; break;
+      default: size_str = "Unknown"; break;
+    }
+    if (this->cached_zone_size_.empty() || strcmp(this->cached_zone_size_.c_str(), size_str) != 0) {
+      this->cached_zone_size_ = size_str;
+      this->zone_size_sensor_->publish_state(this->cached_zone_size_);
+    }
+  }
+  
+  // Normalized size (0-100%)
+  if (this->zone_normalized_size_sensor_ != nullptr) {
+    float norm_size = static_cast<float>(zone.normalized_size);
+    if (!this->zone_normalized_size_sensor_->has_state() ||
+        this->zone_normalized_size_sensor_->raw_state != norm_size) {
+      this->zone_normalized_size_sensor_->publish_state(norm_size);
+    }
+  }
 }
 
 void AuroraClimate::publish_state_if_changed_() {

--- a/components/waterfurnace_aurora/climate/aurora_climate.cpp
+++ b/components/waterfurnace_aurora/climate/aurora_climate.cpp
@@ -256,12 +256,13 @@ void AuroraClimate::update_state_() {
       }
     }
 
-    // Update action based on zone damper and call state
-    // XXX: Dehumidifier detection needs testing during summer cooling season.
-    // See waterfurnace_aurora.cpp for full explanation of the reversing valve gate.
+    // Update action based on zone damper and call state.
+    // Dehumidifier detection: VS active dehumidify is gated on reversing valve (cooling
+    // mode only); AXB dehumidifier relay is gated on has_dehumidifier() (DIP switch).
     bool cooling = (this->parent_->get_system_outputs() & OUTPUT_RV) != 0;
     bool dehumidifying = (this->parent_->is_active_dehumidify() && cooling)
-                         || ((this->parent_->get_axb_outputs() & AXB_OUTPUT_DEHUMIDIFIER) != 0);
+                         || (this->parent_->has_dehumidifier()
+                             && (this->parent_->get_axb_outputs() & AXB_OUTPUT_DEHUMIDIFIER) != 0);
     if (!zone.damper_open) {
       // Zone damper closed — show DRYING only for standalone dehumidifier (AXB relay)
       this->action = dehumidifying ? climate::CLIMATE_ACTION_DRYING : climate::CLIMATE_ACTION_IDLE;
@@ -335,10 +336,11 @@ void AuroraClimate::update_state_() {
     bool cooling = (outputs & OUTPUT_RV) != 0;
     bool aux_heat = (outputs & (OUTPUT_EH1 | OUTPUT_EH2)) != 0;
     bool blower = (outputs & OUTPUT_BLOWER) != 0;
-    // XXX: Dehumidifier detection needs testing during summer cooling season.
-    // See waterfurnace_aurora.cpp for full explanation of the reversing valve gate.
+    // Dehumidifier detection: VS active dehumidify is gated on reversing valve (cooling
+    // mode only); AXB dehumidifier relay is gated on has_dehumidifier() (DIP switch).
     bool dehumidifying = (this->parent_->is_active_dehumidify() && cooling)
-                         || ((this->parent_->get_axb_outputs() & AXB_OUTPUT_DEHUMIDIFIER) != 0);
+                         || (this->parent_->has_dehumidifier()
+                             && (this->parent_->get_axb_outputs() & AXB_OUTPUT_DEHUMIDIFIER) != 0);
     
     if (this->parent_->is_locked_out()) {
       this->action = climate::CLIMATE_ACTION_OFF;

--- a/components/waterfurnace_aurora/climate/aurora_climate.h
+++ b/components/waterfurnace_aurora/climate/aurora_climate.h
@@ -50,8 +50,8 @@ class AuroraClimate : public climate::Climate, public Component {
   text_sensor::TextSensor *zone_priority_sensor_{nullptr};
   text_sensor::TextSensor *zone_size_sensor_{nullptr};
   sensor::Sensor *zone_normalized_size_sensor_{nullptr};
-  std::string cached_zone_priority_;
-  std::string cached_zone_size_;
+  const char *cached_zone_priority_{nullptr};
+  const char *cached_zone_size_{nullptr};
 
   // EMA state for current_temperature smoothing.
   // Suppresses ADC jitter (±0.1°F) from IZ2 zone thermostats so the HA

--- a/components/waterfurnace_aurora/climate/aurora_climate.h
+++ b/components/waterfurnace_aurora/climate/aurora_climate.h
@@ -2,6 +2,8 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/climate/climate.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
 #include "../waterfurnace_aurora.h"
 
 namespace esphome {
@@ -16,6 +18,11 @@ class AuroraClimate : public climate::Climate, public Component {
 
   void set_parent(WaterFurnaceAurora *parent) { this->parent_ = parent; }
   void set_zone(uint8_t zone) { this->zone_ = zone; }
+
+  // Optional per-zone diagnostic sensors (IZ2 only)
+  void set_zone_priority_sensor(text_sensor::TextSensor *sensor) { this->zone_priority_sensor_ = sensor; }
+  void set_zone_size_sensor(text_sensor::TextSensor *sensor) { this->zone_size_sensor_ = sensor; }
+  void set_zone_normalized_size_sensor(sensor::Sensor *sensor) { this->zone_normalized_size_sensor_ = sensor; }
 
   // Climate traits
   climate::ClimateTraits traits() override;
@@ -34,8 +41,17 @@ class AuroraClimate : public climate::Climate, public Component {
     return this->zone_ > 1 || (this->zone_ == 1 && this->parent_->has_iz2());
   }
 
+  void publish_zone_diagnostics_();
+
   WaterFurnaceAurora *parent_{nullptr};
   uint8_t zone_{1};
+
+  // Per-zone diagnostic sensors (IZ2 only)
+  text_sensor::TextSensor *zone_priority_sensor_{nullptr};
+  text_sensor::TextSensor *zone_size_sensor_{nullptr};
+  sensor::Sensor *zone_normalized_size_sensor_{nullptr};
+  std::string cached_zone_priority_;
+  std::string cached_zone_size_;
 
   // EMA state for current_temperature smoothing.
   // Suppresses ADC jitter (±0.1°F) from IZ2 zone thermostats so the HA

--- a/components/waterfurnace_aurora/number/__init__.py
+++ b/components/waterfurnace_aurora/number/__init__.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_MIN_VALUE,
     CONF_MAX_VALUE,
     CONF_STEP,
+    DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_VOLTAGE,
@@ -15,6 +16,9 @@ from esphome.const import (
 )
 
 from .. import waterfurnace_aurora_ns, WaterFurnaceAurora, CONF_AURORA_ID, CONF_ZONE, validate_zone, UNIT_FAHRENHEIT
+
+# Unit definitions
+UNIT_PSI = "psi"
 
 DEPENDENCIES = ["waterfurnace_aurora"]
 CODEOWNERS = ["@daemonp"]
@@ -33,6 +37,8 @@ CONF_FAN_INTERMITTENT_OFF = "fan_intermittent_off"
 CONF_HUMIDIFICATION_TARGET = "humidification_target"
 CONF_DEHUMIDIFICATION_TARGET = "dehumidification_target"
 CONF_LINE_VOLTAGE_SETTING = "line_voltage_setting"
+CONF_COOLING_AIRFLOW_ADJUSTMENT = "cooling_airflow_adjustment"
+CONF_LOOP_PRESSURE_TRIP = "loop_pressure_trip"
 
 # C++ classes
 AuroraDHWNumber = waterfurnace_aurora_ns.class_(
@@ -57,6 +63,8 @@ AURORA_NUMBER_TYPES = {
     CONF_HUMIDIFICATION_TARGET: AuroraNumberType.HUMIDIFICATION_TARGET,
     CONF_DEHUMIDIFICATION_TARGET: AuroraNumberType.DEHUMIDIFICATION_TARGET,
     CONF_LINE_VOLTAGE_SETTING: AuroraNumberType.LINE_VOLTAGE_SETTING,
+    CONF_COOLING_AIRFLOW_ADJUSTMENT: AuroraNumberType.COOLING_AIRFLOW_ADJUSTMENT,
+    CONF_LOOP_PRESSURE_TRIP: AuroraNumberType.LOOP_PRESSURE_TRIP,
 }
 
 # Schema for ECM blower speeds (1-12)
@@ -181,6 +189,32 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_MIN_VALUE, default=90): cv.float_,
                 cv.Optional(CONF_MAX_VALUE, default=635): cv.float_,
                 cv.Optional(CONF_STEP, default=1): cv.float_,
+            }
+        ).extend(cv.COMPONENT_SCHEMA),
+        # Cooling airflow adjustment (gap 12 — NEGATABLE signed int16)
+        cv.Optional(CONF_COOLING_AIRFLOW_ADJUSTMENT): number.number_schema(
+            AuroraNumber,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:fan-chevron-down",
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=-10): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=10): cv.float_,
+                cv.Optional(CONF_STEP, default=1): cv.float_,
+            }
+        ).extend(cv.COMPONENT_SCHEMA),
+        # Loop pressure trip point (gap 11 — TO_TENTHS, writable)
+        cv.Optional(CONF_LOOP_PRESSURE_TRIP): number.number_schema(
+            AuroraNumber,
+            unit_of_measurement=UNIT_PSI,
+            device_class=DEVICE_CLASS_PRESSURE,
+            entity_category=ENTITY_CATEGORY_CONFIG,
+            icon="mdi:gauge",
+        ).extend(
+            {
+                cv.Optional(CONF_MIN_VALUE, default=0): cv.float_,
+                cv.Optional(CONF_MAX_VALUE, default=100): cv.float_,
+                cv.Optional(CONF_STEP, default=0.1): cv.float_,
             }
         ).extend(cv.COMPONENT_SCHEMA),
     }

--- a/components/waterfurnace_aurora/number/aurora_number.cpp
+++ b/components/waterfurnace_aurora/number/aurora_number.cpp
@@ -182,7 +182,9 @@ void AuroraNumber::control(float value) {
 
   // COOLING_AIRFLOW_ADJUSTMENT — signed int16_t (NEGATABLE encoding)
   if (this->type_ == AuroraNumberType::COOLING_AIRFLOW_ADJUSTMENT) {
-    if (this->parent_->set_cooling_airflow_adjustment(static_cast<int16_t>(value))) {
+    // Clamp to int16_t range before cast (YAML schema limits to [-10,10], this is defense-in-depth)
+    float clamped_s = (value < -32768.0f) ? -32768.0f : (value > 32767.0f) ? 32767.0f : value;
+    if (this->parent_->set_cooling_airflow_adjustment(static_cast<int16_t>(clamped_s))) {
       this->publish_state(value);
     }
     return;

--- a/components/waterfurnace_aurora/number/aurora_number.cpp
+++ b/components/waterfurnace_aurora/number/aurora_number.cpp
@@ -124,6 +124,12 @@ void AuroraNumber::update_state_() {
     case AuroraNumberType::LINE_VOLTAGE_SETTING:
       value = this->parent_->get_cached_register(registers::LINE_VOLTAGE_SETTING);
       break;
+    case AuroraNumberType::COOLING_AIRFLOW_ADJUSTMENT:
+      value = this->parent_->get_cached_register_signed(registers::COOLING_AIRFLOW_ADJUSTMENT);
+      break;
+    case AuroraNumberType::LOOP_PRESSURE_TRIP:
+      value = this->parent_->get_cached_register_tenths(registers::LOOP_PRESSURE_TRIP);
+      break;
     default:
       return;
   }
@@ -149,6 +155,8 @@ void AuroraNumber::dump_config() {
     case AuroraNumberType::HUMIDIFICATION_TARGET: type_name = "Humidification Target"; break;
     case AuroraNumberType::DEHUMIDIFICATION_TARGET: type_name = "Dehumidification Target"; break;
     case AuroraNumberType::LINE_VOLTAGE_SETTING: type_name = "Line Voltage Setting"; break;
+    case AuroraNumberType::COOLING_AIRFLOW_ADJUSTMENT: type_name = "Cooling Airflow Adjustment"; break;
+    case AuroraNumberType::LOOP_PRESSURE_TRIP: type_name = "Loop Pressure Trip"; break;
     default: break;
   }
   ESP_LOGCONFIG(TAG, "Aurora Number: %s%s", type_name,
@@ -167,6 +175,22 @@ void AuroraNumber::control(float value) {
   // LINE_VOLTAGE_SETTING needs uint16_t range (90-635), handle before uint8_t clamping
   if (this->type_ == AuroraNumberType::LINE_VOLTAGE_SETTING) {
     if (this->parent_->set_line_voltage_setting(static_cast<uint16_t>(value))) {
+      this->publish_state(value);
+    }
+    return;
+  }
+
+  // COOLING_AIRFLOW_ADJUSTMENT — signed int16_t (NEGATABLE encoding)
+  if (this->type_ == AuroraNumberType::COOLING_AIRFLOW_ADJUSTMENT) {
+    if (this->parent_->set_cooling_airflow_adjustment(static_cast<int16_t>(value))) {
+      this->publish_state(value);
+    }
+    return;
+  }
+
+  // LOOP_PRESSURE_TRIP — float, stored as value * 10
+  if (this->type_ == AuroraNumberType::LOOP_PRESSURE_TRIP) {
+    if (this->parent_->set_loop_pressure_trip(value)) {
       this->publish_state(value);
     }
     return;

--- a/components/waterfurnace_aurora/number/aurora_number.h
+++ b/components/waterfurnace_aurora/number/aurora_number.h
@@ -21,6 +21,8 @@ enum class AuroraNumberType : uint8_t {
   HUMIDIFICATION_TARGET,
   DEHUMIDIFICATION_TARGET,
   LINE_VOLTAGE_SETTING,
+  COOLING_AIRFLOW_ADJUSTMENT,
+  LOOP_PRESSURE_TRIP,
 };
 
 class AuroraDHWNumber : public number::Number, public Component {

--- a/components/waterfurnace_aurora/registers.cpp
+++ b/components/waterfurnace_aurora/registers.cpp
@@ -249,6 +249,54 @@ std::string get_eev2_ctl_string(uint16_t value) {
   return bitmask_to_string(value, EEV2_CTL_BITS, EEV2_CTL_BITS_COUNT);
 }
 
+// ============================================================================
+// Configuration Register String Lookups (gap 11)
+// ============================================================================
+
+const char *get_brine_type_string(uint16_t value) {
+  return (value == 485) ? "Antifreeze" : "Water";
+}
+
+const char *get_flow_meter_type_string(uint16_t value) {
+  switch (value) {
+    case 0: return "None";
+    case 1: return "3/4\"";
+    case 2: return "1\"";
+    default: return "Other";
+  }
+}
+
+const char *get_smartgrid_action_string(uint16_t value) {
+  switch (value) {
+    case 0: return "None";
+    case 1: return "Unoccupied Set Points";
+    case 2: return "Load Shed";
+    case 3: return "Capacity Limiting";
+    case 4: return "Off Time";
+    default: return "Unknown";
+  }
+}
+
+const char *get_ha_alarm_action_string(uint16_t value) {
+  switch (value) {
+    case 0: return "None";
+    case 1: return "General";
+    case 2: return "Security";
+    case 3: return "Sump";
+    case 4: return "Carbon Monoxide";
+    case 5: return "Dirty Filter";
+    default: return "Unknown";
+  }
+}
+
+const char *get_energy_phase_type_string(uint16_t value) {
+  switch (value) {
+    case 0: return "Single";
+    case 1: return "Three";
+    default: return "Other";
+  }
+}
+
 std::string get_axb_inputs_string(uint16_t value) {
   std::string result;
   result.reserve(64);

--- a/components/waterfurnace_aurora/registers.cpp
+++ b/components/waterfurnace_aurora/registers.cpp
@@ -46,6 +46,12 @@ const BitLabel VS_SAFE_MODE_BITS[] = {
   {VS_SAFE_INVALID_AMBIENT_TEMP, "Invalid Ambient Temp"},
 };
 
+const BitLabel EEV2_CTL_BITS[] = {
+  {EEV2_INVALID_SUCTION_TEMP, "Invalid Suction Temp"},
+  {EEV2_INVALID_LEAVING_AIR_TEMP, "Invalid Leaving Air Temp"},
+  {EEV2_INVALID_SUCTION_PRESSURE, "Invalid Suction Pressure"},
+};
+
 // ============================================================================
 // Bitmask-to-String
 // ============================================================================
@@ -237,6 +243,10 @@ std::string get_vs_alarm_string(uint16_t alarm1, uint16_t alarm2) {
   }
 
   return result.empty() ? "Unknown" : result;
+}
+
+std::string get_eev2_ctl_string(uint16_t value) {
+  return bitmask_to_string(value, EEV2_CTL_BITS, EEV2_CTL_BITS_COUNT);
 }
 
 std::string get_axb_inputs_string(uint16_t value) {

--- a/components/waterfurnace_aurora/registers.h
+++ b/components/waterfurnace_aurora/registers.h
@@ -157,6 +157,13 @@ namespace registers {
   static constexpr uint16_t VS_ALARM1 = 217;
   static constexpr uint16_t VS_ALARM2 = 218;
 
+  // EEV2 (independent EEV control block)
+  static constexpr uint16_t EEV2_CTL = 280;             // Bitmask: sensor failure conditions
+  static constexpr uint16_t EEV_SUPERHEAT = 281;
+  static constexpr uint16_t EEV_OPEN = 282;
+  static constexpr uint16_t EEV_SUCTION_TEMP = 283;
+  static constexpr uint16_t EEV_SATURATED_SUCTION_TEMP = 284;
+
   // Blower / ECM
   static constexpr uint16_t VS_PUMP_MIN = 321;
   static constexpr uint16_t VS_PUMP_MAX = 322;
@@ -213,7 +220,12 @@ namespace registers {
   static constexpr uint16_t DISCHARGE_PRESSURE = 1115;
   static constexpr uint16_t SUCTION_PRESSURE = 1116;
   static constexpr uint16_t WATERFLOW = 1117;
+  static constexpr uint16_t AXB_LEAVING_AIR_TEMP = 1112;
+  static constexpr uint16_t AXB_SUCTION_TEMP = 1113;
   static constexpr uint16_t LOOP_PRESSURE = 1119;
+  static constexpr uint16_t SATURATED_EVAPORATOR_TEMP = 1124;
+  static constexpr uint16_t AXB_SUPERHEAT = 1125;
+  static constexpr uint16_t VAPOR_INJECTOR_OPEN = 1126;
   static constexpr uint16_t SATURATED_CONDENSER_TEMP = 1134;
   static constexpr uint16_t SUBCOOL_HEATING = 1135;
   static constexpr uint16_t SUBCOOL_COOLING = 1136;
@@ -257,6 +269,14 @@ namespace registers {
   // Thermostat config (read)
   static constexpr uint16_t FAN_CONFIG = 12005;
   static constexpr uint16_t HEATING_MODE_READ = 12006;
+
+  // Manual operation / test mode
+  static constexpr uint16_t TEST_MODE = 45;
+  static constexpr uint16_t MANUAL_OPERATION = 3002;
+  static constexpr uint16_t MANUAL_OPERATION_OFF = 0x7FFF;
+  static constexpr uint16_t MANUAL_OPERATION_COOLING = 0x100;
+  static constexpr uint16_t MANUAL_OPERATION_AUX_HEAT = 0x200;
+  static constexpr uint16_t MANUAL_BLOWER_WITH_COMPRESSOR = 0xF0;
 
   // System commands
   static constexpr uint16_t CLEAR_FAULT_HISTORY = 47;
@@ -338,6 +358,11 @@ static constexpr uint16_t VS_SAFE_EEV_INDOOR_FAILED = 0x01;
 static constexpr uint16_t VS_SAFE_EEV_OUTDOOR_FAILED = 0x02;
 static constexpr uint16_t VS_SAFE_INVALID_AMBIENT_TEMP = 0x04;
 
+// EEV2 control bitmask (registers 280, 3804) — from registers.rb VS_EEV2
+static constexpr uint16_t EEV2_INVALID_SUCTION_TEMP = 0x0010;
+static constexpr uint16_t EEV2_INVALID_LEAVING_AIR_TEMP = 0x0020;
+static constexpr uint16_t EEV2_INVALID_SUCTION_PRESSURE = 0x0040;
+
 // ============================================================================
 // Bitmask-to-String Helpers
 // ============================================================================
@@ -363,6 +388,9 @@ inline constexpr size_t VS_DERATE_BITS_COUNT = 5;
 
 extern const BitLabel VS_SAFE_MODE_BITS[];
 inline constexpr size_t VS_SAFE_MODE_BITS_COUNT = 3;
+
+extern const BitLabel EEV2_CTL_BITS[];
+inline constexpr size_t EEV2_CTL_BITS_COUNT = 3;
 
 // ============================================================================
 // Data Conversion Functions
@@ -424,6 +452,9 @@ std::string get_vs_safe_mode_string(uint16_t value);
 
 /// Get VS alarm string from two alarm registers.
 std::string get_vs_alarm_string(uint16_t alarm1, uint16_t alarm2);
+
+/// Get EEV2 control status string from bitmask.
+std::string get_eev2_ctl_string(uint16_t value);
 
 /// Get AXB inputs string from bitmask.
 std::string get_axb_inputs_string(uint16_t value);

--- a/components/waterfurnace_aurora/registers.h
+++ b/components/waterfurnace_aurora/registers.h
@@ -164,6 +164,9 @@ namespace registers {
   static constexpr uint16_t EEV_SUCTION_TEMP = 283;
   static constexpr uint16_t EEV_SATURATED_SUCTION_TEMP = 284;
 
+  // Condensate monitoring (gap 13)
+  static constexpr uint16_t CONDENSATE = 21;
+
   // Blower / ECM
   static constexpr uint16_t VS_PUMP_MIN = 321;
   static constexpr uint16_t VS_PUMP_MAX = 322;
@@ -173,6 +176,7 @@ namespace registers {
   static constexpr uint16_t LO_COMPRESSOR_ECM_SPEED = 341;
   static constexpr uint16_t HI_COMPRESSOR_ECM_SPEED = 342;
   static constexpr uint16_t ECM_SPEED = 344;
+  static constexpr uint16_t COOLING_AIRFLOW_ADJUSTMENT = 346;  // Signed, writable (gap 12)
   static constexpr uint16_t AUX_HEAT_ECM_SPEED = 347;
   static constexpr uint16_t ACTIVE_DEHUMIDIFY = 362;
 
@@ -180,10 +184,25 @@ namespace registers {
   static constexpr uint16_t DHW_ENABLED = 400;
   static constexpr uint16_t DHW_SETPOINT = 401;
 
+  // Configuration/settings registers (gap 11)
+  static constexpr uint16_t BRINE_TYPE_REG = 402;
+  static constexpr uint16_t FLOW_METER_TYPE_REG = 403;
+
   // Hardware detection
   static constexpr uint16_t BLOWER_TYPE = 404;
+  static constexpr uint16_t SMARTGRID_TRIGGER = 405;
+  static constexpr uint16_t SMARTGRID_ACTION_REG = 406;
+  static constexpr uint16_t OFF_TIME_LENGTH = 407;
+  static constexpr uint16_t HA_ALARM1_TRIGGER = 408;
+  static constexpr uint16_t HA_ALARM1_ACTION = 409;
+  static constexpr uint16_t HA_ALARM2_TRIGGER = 410;
+  static constexpr uint16_t HA_ALARM2_ACTION = 411;
   static constexpr uint16_t ENERGY_MONITOR = 412;
   static constexpr uint16_t PUMP_TYPE = 413;
+  static constexpr uint16_t ENERGY_PHASE_TYPE_REG = 416;
+  static constexpr uint16_t POWER_ADJ_FACTOR_L = 417;
+  static constexpr uint16_t POWER_ADJ_FACTOR_H = 418;
+  static constexpr uint16_t LOOP_PRESSURE_TRIP = 419;  // Writable, TO_TENTHS
 
   // IZ2 system registers
   static constexpr uint16_t IZ2_NUM_ZONES = 483;
@@ -261,6 +280,15 @@ namespace registers {
   static constexpr uint16_t VS_INVERTER_TEMP = 3522;
   static constexpr uint16_t VS_UDC_VOLTAGE = 3523;
   static constexpr uint16_t VS_FAN_SPEED = 3524;
+  // VS Drive 3200-range duplicates (gap 14) — same bitmasks as 200-range
+  static constexpr uint16_t VS_DRIVE_DERATE_ALT = 3223;
+  static constexpr uint16_t VS_DRIVE_SAFE_MODE_ALT = 3225;
+  static constexpr uint16_t VS_DRIVE_ALARM1_ALT = 3226;
+  static constexpr uint16_t VS_DRIVE_ALARM2_ALT = 3227;
+
+  // VS Drive EEV2 Ctl duplicate (gap 15) — same bitmask as EEV2_CTL (280)
+  static constexpr uint16_t VS_DRIVE_EEV2_CTL = 3804;
+
   static constexpr uint16_t VS_EEV_OPEN = 3808;
   static constexpr uint16_t VS_SUCTION_TEMP = 3903;
   static constexpr uint16_t VS_SAT_EVAP_DISCHARGE_TEMP = 3905;
@@ -311,6 +339,16 @@ namespace registers {
   static constexpr uint16_t IZ2_CONFIG1_BASE = 31008;
   static constexpr uint16_t IZ2_CONFIG2_BASE = 31009;
   static constexpr uint16_t IZ2_CONFIG3_BASE = 31200;
+
+  // Dealer information (gap 19) — multi-register ASCII strings
+  static constexpr uint16_t DEALER_NAME = 31400;         // 13 registers (26 chars)
+  static constexpr uint16_t DEALER_PHONE = 31413;        // 8 registers (16 chars)
+  static constexpr uint16_t DEALER_ADDRESS1 = 31421;     // 13 registers (26 chars)
+  static constexpr uint16_t DEALER_ADDRESS2 = 31434;     // 13 registers (26 chars)
+  static constexpr uint16_t DEALER_EMAIL = 31447;        // 13 registers (26 chars)
+  static constexpr uint16_t DEALER_WEBSITE = 31460;      // 13 registers (26 chars)
+  static constexpr uint16_t DEALER_INFO_START = 31400;
+  static constexpr uint16_t DEALER_INFO_COUNT = 73;      // 31400-31472
 }  // namespace registers
 
 // ============================================================================
@@ -410,6 +448,11 @@ inline float to_tenths(uint16_t value) {
   return value / 10.0f;
 }
 
+/// Convert raw unsigned hundredths (uint16 / 100.0). For power adjustment factors.
+inline float to_hundredths(uint16_t value) {
+  return value / 100.0f;
+}
+
 /// Assemble two consecutive 16-bit registers into uint32 (high word first).
 inline uint32_t to_uint32(uint16_t high, uint16_t low) {
   return (static_cast<uint32_t>(high) << 16) | low;
@@ -455,6 +498,21 @@ std::string get_vs_alarm_string(uint16_t alarm1, uint16_t alarm2);
 
 /// Get EEV2 control status string from bitmask.
 std::string get_eev2_ctl_string(uint16_t value);
+
+/// Get brine type string (register 402). Ruby: BRINE_TYPE enum.
+const char *get_brine_type_string(uint16_t value);
+
+/// Get flow meter type string (register 403). Ruby: FLOW_METER_TYPE enum.
+const char *get_flow_meter_type_string(uint16_t value);
+
+/// Get SmartGrid action string (register 406). Ruby: SMARTGRID_ACTION enum.
+const char *get_smartgrid_action_string(uint16_t value);
+
+/// Get HA alarm action string (registers 409, 411). Ruby: HA_ALARM enum.
+const char *get_ha_alarm_action_string(uint16_t value);
+
+/// Get energy phase type string (register 416). Ruby: PHASE_TYPE enum.
+const char *get_energy_phase_type_string(uint16_t value);
 
 /// Get AXB inputs string from bitmask.
 std::string get_axb_inputs_string(uint16_t value);

--- a/components/waterfurnace_aurora/registers.h
+++ b/components/waterfurnace_aurora/registers.h
@@ -62,6 +62,40 @@ enum class PumpType : uint8_t {
   OTHER = 255
 };
 
+// DIP Switch accessory relay settings (from registers.rb ACCESSORY_RELAY_SETTINGS)
+enum class AccessoryRelay : uint8_t {
+  COMPRESSOR = 0,
+  SLOW_OPENING_WATER_VALVE = 1,
+  HUMIDIFIER = 2,
+  BLOWER = 3
+};
+
+// AXB accessory relay 2 mode (from registers.rb axb_inputs bits 7-8)
+enum class AxbAccessoryRelay2 : uint8_t {
+  DEHUMIDIFIER = 0,        // Neither bit 7 nor bit 8 set
+  HIGH_CAPACITY_COMPRESSOR = 1,  // Bit 7 only
+  LOW_CAPACITY_COMPRESSOR = 2,   // Bit 8 only
+  BLOWER = 3               // Both bits 7 and 8 set
+};
+
+// DIP Switch reversing valve type
+enum class ReversingValveType : uint8_t {
+  B_TYPE = 0,  // Energize to heat
+  O_TYPE = 1   // Energize to cool
+};
+
+// DIP Switch lockout behavior
+enum class LockoutType : uint8_t {
+  PULSE = 0,
+  CONTINUOUS = 1
+};
+
+// DIP Switch dehumidifier/reheat setting
+enum class DehumidifierReheat : uint8_t {
+  REHEAT = 0,
+  DEHUMIDIFIER = 1
+};
+
 // IZ2 Zone current mode/call (from registers.rb CALLS hash)
 enum class ZoneCall : uint8_t {
   STANDBY = 0,
@@ -111,6 +145,7 @@ namespace registers {
   static constexpr uint16_t INPUTS_AT_LOCKOUT = 28;      // Bitmask: system status/inputs when lockout occurred
   static constexpr uint16_t SYSTEM_OUTPUTS = 30;
   static constexpr uint16_t SYSTEM_STATUS = 31;
+  static constexpr uint16_t DIP_SWITCH_STATUS = 33;  // ABC DIP switch bitmask
   static constexpr uint16_t ABC_PROGRAM = 88;         // 4 registers (88-91) — program version string
   static constexpr uint16_t MODEL_NUMBER = 92;        // 12 registers (92-103)
   static constexpr uint16_t SERIAL_NUMBER = 105;      // 5 registers (105-109)
@@ -398,6 +433,52 @@ std::string get_outputs_string(uint16_t value);
 
 /// Get system inputs/status string from bitmask (for lockout diagnostics).
 std::string get_inputs_string(uint16_t value);
+
+// ============================================================================
+// DIP Switch Parsing (register 33 — from registers.rb dipswitch_settings)
+// ============================================================================
+
+/// Parsed DIP switch settings from register 33.
+/// Special case: when raw value is 0x7FFF, the system is in manual DIP switch mode.
+struct DipSwitchSettings {
+  bool manual{false};                                    ///< 0x7FFF = manual mode
+  uint8_t fp1{15};                                       ///< Freeze protection 1 delta: 15 or 30
+  uint8_t fp2{0};                                        ///< Freeze protection 2 delta: 30, or 0 = off
+  ReversingValveType reversing_valve{ReversingValveType::B_TYPE};
+  AccessoryRelay accessory_relay{AccessoryRelay::COMPRESSOR};
+  uint8_t compressor_stages{2};                          ///< 1 = single stage, 2 = dual stage
+  LockoutType lockout{LockoutType::PULSE};
+  DehumidifierReheat dehumidifier_reheat{DehumidifierReheat::REHEAT};
+};
+
+/// Parse register 33 (or 4) DIP switch bitmask into structured settings.
+/// Matches Ruby gem registers.rb:211-223 dipswitch_settings().
+inline DipSwitchSettings parse_dip_switches(uint16_t value) {
+  DipSwitchSettings ds;
+  if (value == 0x7FFF) {
+    ds.manual = true;
+    return ds;
+  }
+  ds.fp1 = (value & 0x01) ? 30 : 15;
+  ds.fp2 = (value & 0x02) ? 30 : 0;  // 0 = off
+  ds.reversing_valve = (value & 0x04) ? ReversingValveType::O_TYPE : ReversingValveType::B_TYPE;
+  ds.accessory_relay = static_cast<AccessoryRelay>((value >> 3) & 0x03);
+  ds.compressor_stages = (value & 0x20) ? 1 : 2;
+  ds.lockout = (value & 0x40) ? LockoutType::CONTINUOUS : LockoutType::PULSE;
+  ds.dehumidifier_reheat = (value & 0x80) ? DehumidifierReheat::DEHUMIDIFIER : DehumidifierReheat::REHEAT;
+  return ds;
+}
+
+/// Extract AXB accessory relay 2 mode from AXB inputs register 1103.
+/// Matches Ruby gem registers.rb:322-330 axb_inputs().
+inline AxbAccessoryRelay2 axb_extract_accessory_relay2(uint16_t axb_inputs) {
+  bool bit7 = (axb_inputs & 0x080) != 0;
+  bool bit8 = (axb_inputs & 0x100) != 0;
+  if (bit7 && bit8) return AxbAccessoryRelay2::BLOWER;
+  if (bit8) return AxbAccessoryRelay2::LOW_CAPACITY_COMPRESSOR;
+  if (bit7) return AxbAccessoryRelay2::HIGH_CAPACITY_COMPRESSOR;
+  return AxbAccessoryRelay2::DEHUMIDIFIER;
+}
 
 // ============================================================================
 // IZ2 Zone Extraction Helpers

--- a/components/waterfurnace_aurora/select/__init__.py
+++ b/components/waterfurnace_aurora/select/__init__.py
@@ -10,11 +10,18 @@ CODEOWNERS = ["@daemonp"]
 
 CONF_HUMIDIFIER_MODE = "humidifier_mode"
 CONF_DEHUMIDIFIER_MODE = "dehumidifier_mode"
+CONF_MANUAL_OPERATION = "manual_operation"
+CONF_COMPRESSOR_SPEED = "compressor_speed"
+CONF_BLOWER_SPEED = "blower_speed"
 
 AuroraHumidistatSelect = waterfurnace_aurora_ns.class_(
     "AuroraHumidistatSelect", select.Select, cg.Component
 )
 AuroraHumidistatType = waterfurnace_aurora_ns.enum("AuroraHumidistatType", is_class=True)
+
+AuroraManualOperationSelect = waterfurnace_aurora_ns.class_(
+    "AuroraManualOperationSelect", select.Select, cg.Component
+)
 
 HUMIDISTAT_SELECT_SCHEMA = select.select_schema(
     AuroraHumidistatSelect,
@@ -22,11 +29,23 @@ HUMIDISTAT_SELECT_SCHEMA = select.select_schema(
     icon="mdi:water-percent",
 ).extend(cv.COMPONENT_SCHEMA)
 
+MANUAL_OPERATION_SELECT_SCHEMA = select.select_schema(
+    AuroraManualOperationSelect,
+    entity_category=ENTITY_CATEGORY_CONFIG,
+    icon="mdi:wrench-cog",
+).extend(cv.COMPONENT_SCHEMA).extend(
+    {
+        cv.Optional(CONF_COMPRESSOR_SPEED, default=8): cv.int_range(min=0, max=15),
+        cv.Optional(CONF_BLOWER_SPEED, default=255): cv.int_range(min=0, max=255),
+    }
+)
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_AURORA_ID): cv.use_id(WaterFurnaceAurora),
         cv.Optional(CONF_HUMIDIFIER_MODE): HUMIDISTAT_SELECT_SCHEMA,
         cv.Optional(CONF_DEHUMIDIFIER_MODE): HUMIDISTAT_SELECT_SCHEMA,
+        cv.Optional(CONF_MANUAL_OPERATION): MANUAL_OPERATION_SELECT_SCHEMA,
     }
 )
 
@@ -45,3 +64,13 @@ async def to_code(config):
         await cg.register_component(var, dehumidifier_config)
         cg.add(var.set_parent(parent))
         cg.add(var.set_type(AuroraHumidistatType.DEHUMIDIFIER))
+
+    if manual_config := config.get(CONF_MANUAL_OPERATION):
+        var = await select.new_select(
+            manual_config,
+            options=["Off", "Heating", "Cooling", "Heating+Aux"],
+        )
+        await cg.register_component(var, manual_config)
+        cg.add(var.set_parent(parent))
+        cg.add(var.set_compressor_speed(manual_config[CONF_COMPRESSOR_SPEED]))
+        cg.add(var.set_blower_speed(manual_config[CONF_BLOWER_SPEED]))

--- a/components/waterfurnace_aurora/select/__init__.py
+++ b/components/waterfurnace_aurora/select/__init__.py
@@ -29,14 +29,21 @@ HUMIDISTAT_SELECT_SCHEMA = select.select_schema(
     icon="mdi:water-percent",
 ).extend(cv.COMPONENT_SCHEMA)
 
+def validate_blower_speed(value):
+    """Validate blower speed: 0-12 for manual speed, or 255 for 'with_compressor' (auto)."""
+    value = cv.int_(value)
+    if value == 255 or 0 <= value <= 12:
+        return value
+    raise cv.Invalid("Blower speed must be 0-12 (manual) or 255 (auto/with_compressor)")
+
 MANUAL_OPERATION_SELECT_SCHEMA = select.select_schema(
     AuroraManualOperationSelect,
     entity_category=ENTITY_CATEGORY_CONFIG,
     icon="mdi:wrench-cog",
 ).extend(cv.COMPONENT_SCHEMA).extend(
     {
-        cv.Optional(CONF_COMPRESSOR_SPEED, default=8): cv.int_range(min=0, max=15),
-        cv.Optional(CONF_BLOWER_SPEED, default=255): cv.int_range(min=0, max=255),
+        cv.Optional(CONF_COMPRESSOR_SPEED, default=8): cv.int_range(min=0, max=12),
+        cv.Optional(CONF_BLOWER_SPEED, default=255): validate_blower_speed,
     }
 )
 

--- a/components/waterfurnace_aurora/select/aurora_humidistat_select.cpp
+++ b/components/waterfurnace_aurora/select/aurora_humidistat_select.cpp
@@ -56,5 +56,51 @@ void AuroraHumidistatSelect::control(const std::string &value) {
   }
 }
 
+// ============================================================================
+// Manual Operation Select
+// ============================================================================
+
+void AuroraManualOperationSelect::setup() {
+  // No listener needed — manual mode is write-only (no read-back register to track).
+  // The initial state is "Off".
+  this->publish_state("Off");
+}
+
+void AuroraManualOperationSelect::dump_config() {
+  ESP_LOGCONFIG(TAG, "Aurora Manual Operation Select:");
+  ESP_LOGCONFIG(TAG, "  Parent: %s", this->parent_ != nullptr ? "configured" : "NOT SET");
+  ESP_LOGCONFIG(TAG, "  Default compressor speed: %d", this->compressor_speed_);
+  if (this->blower_speed_ == 255) {
+    ESP_LOGCONFIG(TAG, "  Default blower speed: auto (with compressor)");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Default blower speed: %d", this->blower_speed_);
+  }
+}
+
+void AuroraManualOperationSelect::control(const std::string &value) {
+  if (this->parent_ == nullptr) {
+    ESP_LOGW(TAG, "Parent not set, cannot control manual operation");
+    return;
+  }
+
+  bool success;
+  if (value == "Off") {
+    success = this->parent_->set_manual_operation_off();
+  } else if (value == "Heating") {
+    success = this->parent_->set_manual_operation(1, this->compressor_speed_, this->blower_speed_, false);
+  } else if (value == "Cooling") {
+    success = this->parent_->set_manual_operation(2, this->compressor_speed_, this->blower_speed_, false);
+  } else if (value == "Heating+Aux") {
+    success = this->parent_->set_manual_operation(1, this->compressor_speed_, this->blower_speed_, true);
+  } else {
+    ESP_LOGW(TAG, "Unknown manual operation mode: %s", value.c_str());
+    return;
+  }
+
+  if (success) {
+    this->publish_state(value);
+  }
+}
+
 }  // namespace waterfurnace_aurora
 }  // namespace esphome

--- a/components/waterfurnace_aurora/select/aurora_humidistat_select.cpp
+++ b/components/waterfurnace_aurora/select/aurora_humidistat_select.cpp
@@ -56,51 +56,6 @@ void AuroraHumidistatSelect::control(const std::string &value) {
   }
 }
 
-// ============================================================================
-// Manual Operation Select
-// ============================================================================
-
-void AuroraManualOperationSelect::setup() {
-  // No listener needed — manual mode is write-only (no read-back register to track).
-  // The initial state is "Off".
-  this->publish_state("Off");
-}
-
-void AuroraManualOperationSelect::dump_config() {
-  ESP_LOGCONFIG(TAG, "Aurora Manual Operation Select:");
-  ESP_LOGCONFIG(TAG, "  Parent: %s", this->parent_ != nullptr ? "configured" : "NOT SET");
-  ESP_LOGCONFIG(TAG, "  Default compressor speed: %d", this->compressor_speed_);
-  if (this->blower_speed_ == 255) {
-    ESP_LOGCONFIG(TAG, "  Default blower speed: auto (with compressor)");
-  } else {
-    ESP_LOGCONFIG(TAG, "  Default blower speed: %d", this->blower_speed_);
-  }
-}
-
-void AuroraManualOperationSelect::control(const std::string &value) {
-  if (this->parent_ == nullptr) {
-    ESP_LOGW(TAG, "Parent not set, cannot control manual operation");
-    return;
-  }
-
-  bool success;
-  if (value == "Off") {
-    success = this->parent_->set_manual_operation_off();
-  } else if (value == "Heating") {
-    success = this->parent_->set_manual_operation(1, this->compressor_speed_, this->blower_speed_, false);
-  } else if (value == "Cooling") {
-    success = this->parent_->set_manual_operation(2, this->compressor_speed_, this->blower_speed_, false);
-  } else if (value == "Heating+Aux") {
-    success = this->parent_->set_manual_operation(1, this->compressor_speed_, this->blower_speed_, true);
-  } else {
-    ESP_LOGW(TAG, "Unknown manual operation mode: %s", value.c_str());
-    return;
-  }
-
-  if (success) {
-    this->publish_state(value);
-  }
-}
 
 }  // namespace waterfurnace_aurora
 }  // namespace esphome

--- a/components/waterfurnace_aurora/select/aurora_humidistat_select.h
+++ b/components/waterfurnace_aurora/select/aurora_humidistat_select.h
@@ -32,5 +32,28 @@ class AuroraHumidistatSelect : public select::Select, public Component {
   bool last_auto_{false};
 };
 
+/// Select entity for manual operation mode (commissioning).
+/// Options: Off, Heating, Cooling, Heating+Aux
+/// When switched from Off to a mode, writes register 3002 with the configured
+/// compressor/blower speeds. When switched to Off, writes 0x7FFF.
+class AuroraManualOperationSelect : public select::Select, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  float get_setup_priority() const override { return setup_priority::PROCESSOR; }
+
+  void set_parent(WaterFurnaceAurora *parent) { this->parent_ = parent; }
+  void set_compressor_speed(uint8_t speed) { this->compressor_speed_ = speed; }
+  void set_blower_speed(uint8_t speed) { this->blower_speed_ = speed; }
+
+ protected:
+  void control(const std::string &value) override;
+
+  WaterFurnaceAurora *parent_{nullptr};
+  uint8_t compressor_speed_{8};   ///< Default compressor speed for manual mode
+  uint8_t blower_speed_{255};     ///< 255 = "with_compressor" (auto), 0-15 = manual
+};
+
 }  // namespace waterfurnace_aurora
 }  // namespace esphome

--- a/components/waterfurnace_aurora/select/aurora_humidistat_select.h
+++ b/components/waterfurnace_aurora/select/aurora_humidistat_select.h
@@ -32,28 +32,6 @@ class AuroraHumidistatSelect : public select::Select, public Component {
   bool last_auto_{false};
 };
 
-/// Select entity for manual operation mode (commissioning).
-/// Options: Off, Heating, Cooling, Heating+Aux
-/// When switched from Off to a mode, writes register 3002 with the configured
-/// compressor/blower speeds. When switched to Off, writes 0x7FFF.
-class AuroraManualOperationSelect : public select::Select, public Component {
- public:
-  void setup() override;
-  void dump_config() override;
-
-  float get_setup_priority() const override { return setup_priority::PROCESSOR; }
-
-  void set_parent(WaterFurnaceAurora *parent) { this->parent_ = parent; }
-  void set_compressor_speed(uint8_t speed) { this->compressor_speed_ = speed; }
-  void set_blower_speed(uint8_t speed) { this->blower_speed_ = speed; }
-
- protected:
-  void control(const std::string &value) override;
-
-  WaterFurnaceAurora *parent_{nullptr};
-  uint8_t compressor_speed_{8};   ///< Default compressor speed for manual mode
-  uint8_t blower_speed_{255};     ///< 255 = "with_compressor" (auto), 0-15 = manual
-};
 
 }  // namespace waterfurnace_aurora
 }  // namespace esphome

--- a/components/waterfurnace_aurora/select/aurora_manual_operation_select.cpp
+++ b/components/waterfurnace_aurora/select/aurora_manual_operation_select.cpp
@@ -1,0 +1,52 @@
+#include "aurora_manual_operation_select.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace waterfurnace_aurora {
+
+static const char *const TAG = "aurora.manual_operation";
+
+void AuroraManualOperationSelect::setup() {
+  // No listener needed — manual mode is write-only (no read-back register to track).
+  // The initial state is "Off".
+  this->publish_state("Off");
+}
+
+void AuroraManualOperationSelect::dump_config() {
+  ESP_LOGCONFIG(TAG, "Aurora Manual Operation Select:");
+  ESP_LOGCONFIG(TAG, "  Parent: %s", this->parent_ != nullptr ? "configured" : "NOT SET");
+  ESP_LOGCONFIG(TAG, "  Default compressor speed: %d", this->compressor_speed_);
+  if (this->blower_speed_ == 255) {
+    ESP_LOGCONFIG(TAG, "  Default blower speed: auto (with compressor)");
+  } else {
+    ESP_LOGCONFIG(TAG, "  Default blower speed: %d", this->blower_speed_);
+  }
+}
+
+void AuroraManualOperationSelect::control(const std::string &value) {
+  if (this->parent_ == nullptr) {
+    ESP_LOGW(TAG, "Parent not set, cannot control manual operation");
+    return;
+  }
+
+  bool success;
+  if (value == "Off") {
+    success = this->parent_->set_manual_operation_off();
+  } else if (value == "Heating") {
+    success = this->parent_->set_manual_operation(1, this->compressor_speed_, this->blower_speed_, false);
+  } else if (value == "Cooling") {
+    success = this->parent_->set_manual_operation(2, this->compressor_speed_, this->blower_speed_, false);
+  } else if (value == "Heating+Aux") {
+    success = this->parent_->set_manual_operation(1, this->compressor_speed_, this->blower_speed_, true);
+  } else {
+    ESP_LOGW(TAG, "Unknown manual operation mode: %s", value.c_str());
+    return;
+  }
+
+  if (success) {
+    this->publish_state(value);
+  }
+}
+
+}  // namespace waterfurnace_aurora
+}  // namespace esphome

--- a/components/waterfurnace_aurora/select/aurora_manual_operation_select.h
+++ b/components/waterfurnace_aurora/select/aurora_manual_operation_select.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/select/select.h"
+#include "../waterfurnace_aurora.h"
+
+namespace esphome {
+namespace waterfurnace_aurora {
+
+/// Select entity for manual operation mode (commissioning).
+/// Options: Off, Heating, Cooling, Heating+Aux
+/// When switched from Off to a mode, writes register 3002 with the configured
+/// compressor/blower speeds. When switched to Off, writes 0x7FFF.
+class AuroraManualOperationSelect : public select::Select, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  float get_setup_priority() const override { return setup_priority::PROCESSOR; }
+
+  void set_parent(WaterFurnaceAurora *parent) { this->parent_ = parent; }
+  void set_compressor_speed(uint8_t speed) { this->compressor_speed_ = speed; }
+  void set_blower_speed(uint8_t speed) { this->blower_speed_ = speed; }
+
+ protected:
+  void control(const std::string &value) override;
+
+  WaterFurnaceAurora *parent_{nullptr};
+  uint8_t compressor_speed_{8};   ///< Default compressor speed for manual mode
+  uint8_t blower_speed_{255};     ///< 255 = "with_compressor" (auto), 0-15 = manual
+};
+
+}  // namespace waterfurnace_aurora
+}  // namespace esphome

--- a/components/waterfurnace_aurora/sensor/__init__.py
+++ b/components/waterfurnace_aurora/sensor/__init__.py
@@ -209,6 +209,27 @@ SENSORS = {
         device_class=DEVICE_CLASS_HUMIDITY,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
+    # AXB diagnostic sensors
+    "axb_leaving_air_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "axb_suction_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "saturated_evaporator_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "axb_superheat": TEMPERATURE_SENSOR_SCHEMA,
+    "vapor_injector_open": sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    # EEV2 diagnostic sensors
+    "eev_superheat": TEMPERATURE_SENSOR_SCHEMA,
+    "eev_open": sensor.sensor_schema(
+        unit_of_measurement=UNIT_PERCENT,
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "eev_suction_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "eev_saturated_suction_temperature": TEMPERATURE_SENSOR_SCHEMA,
     # IZ2 desired speed sensors
     "iz2_compressor_speed": SPEED_SENSOR_SCHEMA,
     "iz2_blower_speed": PERCENT_SENSOR_SCHEMA,
@@ -230,10 +251,22 @@ SENSORS = {
     ),
 }
 
+# Fault history counter schema — state_class: total_increasing per Ruby gem
+FAULT_COUNTER_SCHEMA = sensor.sensor_schema(
+    accuracy_decimals=0,
+    state_class="total_increasing",
+    entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+)
+
+# Generate E1-E99 fault counter sensor keys
+FAULT_COUNTERS = {f"fault_e{i}": FAULT_COUNTER_SCHEMA for i in range(1, 100)}
+
 CONFIG_SCHEMA = cv.Schema(
     {cv.GenerateID(CONF_AURORA_ID): cv.use_id(WaterFurnaceAurora)}
 ).extend(
     {cv.Optional(key): schema for key, schema in SENSORS.items()}
+).extend(
+    {cv.Optional(key): schema for key, schema in FAULT_COUNTERS.items()}
 )
 
 
@@ -243,3 +276,10 @@ async def to_code(config):
         if conf := config.get(key):
             sens = await sensor.new_sensor(conf)
             cg.add(getattr(parent, f"set_{key}_sensor")(sens))
+    # Fault history counters — use set_fault_counter_sensor(index, sensor)
+    for i in range(1, 100):
+        key = f"fault_e{i}"
+        if conf := config.get(key):
+            sens = await sensor.new_sensor(conf)
+            cg.add(parent.set_fault_counter_sensor(i - 1, sens))
+            cg.add(parent.set_has_any_fault_counter_sensor())

--- a/components/waterfurnace_aurora/sensor/__init__.py
+++ b/components/waterfurnace_aurora/sensor/__init__.py
@@ -244,6 +244,29 @@ SENSORS = {
         state_class=STATE_CLASS_MEASUREMENT,
         entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
     ),
+    # Configuration sensors (gap 11)
+    "off_time_length": sensor.sensor_schema(
+        unit_of_measurement="s",
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "power_adj_factor_l": sensor.sensor_schema(
+        accuracy_decimals=2,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    "power_adj_factor_h": sensor.sensor_schema(
+        accuracy_decimals=2,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
+    # Condensate monitoring (gap 13)
+    "condensate": sensor.sensor_schema(
+        accuracy_decimals=0,
+        state_class=STATE_CLASS_MEASUREMENT,
+        entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+    ),
     # Derived sensors (computed on-device)
     "cop": sensor.sensor_schema(
         accuracy_decimals=2,

--- a/components/waterfurnace_aurora/sensor/__init__.py
+++ b/components/waterfurnace_aurora/sensor/__init__.py
@@ -11,6 +11,7 @@ from esphome.const import (
     DEVICE_CLASS_PRESSURE,
     ENTITY_CATEGORY_DIAGNOSTIC,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
     UNIT_AMPERE,
     UNIT_CELSIUS,
     UNIT_PERCENT,
@@ -277,7 +278,7 @@ SENSORS = {
 # Fault history counter schema — state_class: total_increasing per Ruby gem
 FAULT_COUNTER_SCHEMA = sensor.sensor_schema(
     accuracy_decimals=0,
-    state_class="total_increasing",
+    state_class=STATE_CLASS_TOTAL_INCREASING,
     entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
 )
 

--- a/components/waterfurnace_aurora/switch/__init__.py
+++ b/components/waterfurnace_aurora/switch/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
+from esphome.const import ENTITY_CATEGORY_CONFIG
 from .. import waterfurnace_aurora_ns, WaterFurnaceAurora, CONF_AURORA_ID
 
 DEPENDENCIES = ["waterfurnace_aurora"]
@@ -8,12 +9,16 @@ CODEOWNERS = ["@daemonp"]
 
 CONF_DHW_ENABLED = "dhw_enabled"
 CONF_PUMP_MANUAL_CONTROL = "pump_manual_control"
+CONF_TEST_MODE = "test_mode"
 
 AuroraDHWSwitch = waterfurnace_aurora_ns.class_(
     "AuroraDHWSwitch", switch.Switch, cg.Component
 )
 AuroraPumpManualSwitch = waterfurnace_aurora_ns.class_(
     "AuroraPumpManualSwitch", switch.Switch, cg.Component
+)
+AuroraTestModeSwitch = waterfurnace_aurora_ns.class_(
+    "AuroraTestModeSwitch", switch.Switch, cg.Component
 )
 
 CONFIG_SCHEMA = cv.Schema(
@@ -26,6 +31,11 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_PUMP_MANUAL_CONTROL): switch.switch_schema(
             AuroraPumpManualSwitch,
             icon="mdi:pump",
+        ).extend(cv.COMPONENT_SCHEMA),
+        cv.Optional(CONF_TEST_MODE): switch.switch_schema(
+            AuroraTestModeSwitch,
+            icon="mdi:test-tube",
+            entity_category=ENTITY_CATEGORY_CONFIG,
         ).extend(cv.COMPONENT_SCHEMA),
     }
 )
@@ -42,4 +52,9 @@ async def to_code(config):
     if pump_config := config.get(CONF_PUMP_MANUAL_CONTROL):
         var = await switch.new_switch(pump_config)
         await cg.register_component(var, pump_config)
+        cg.add(var.set_parent(parent))
+
+    if test_config := config.get(CONF_TEST_MODE):
+        var = await switch.new_switch(test_config)
+        await cg.register_component(var, test_config)
         cg.add(var.set_parent(parent))

--- a/components/waterfurnace_aurora/switch/aurora_test_mode_switch.cpp
+++ b/components/waterfurnace_aurora/switch/aurora_test_mode_switch.cpp
@@ -1,0 +1,31 @@
+#include "aurora_test_mode_switch.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace waterfurnace_aurora {
+
+static const char *const TAG = "aurora.test_mode_switch";
+
+void AuroraTestModeSwitch::setup() {
+  // Test mode is write-only — start in OFF state.
+  this->publish_state(false);
+}
+
+void AuroraTestModeSwitch::dump_config() {
+  ESP_LOGCONFIG(TAG, "Aurora Test Mode Switch:");
+  ESP_LOGCONFIG(TAG, "  Parent: %s", this->parent_ != nullptr ? "configured" : "NOT SET");
+}
+
+void AuroraTestModeSwitch::write_state(bool state) {
+  if (this->parent_ == nullptr) {
+    ESP_LOGW(TAG, "Parent not set, cannot control test mode");
+    return;
+  }
+
+  if (this->parent_->set_test_mode(state)) {
+    this->publish_state(state);
+  }
+}
+
+}  // namespace waterfurnace_aurora
+}  // namespace esphome

--- a/components/waterfurnace_aurora/switch/aurora_test_mode_switch.h
+++ b/components/waterfurnace_aurora/switch/aurora_test_mode_switch.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/switch/switch.h"
+#include "../waterfurnace_aurora.h"
+
+namespace esphome {
+namespace waterfurnace_aurora {
+
+/// Switch entity for test mode (register 45).
+/// Write-only: 1 = enable, 0 = disable. No read-back register.
+class AuroraTestModeSwitch : public switch_::Switch, public Component {
+ public:
+  void setup() override;
+  void dump_config() override;
+
+  float get_setup_priority() const override { return setup_priority::PROCESSOR; }
+
+  void set_parent(WaterFurnaceAurora *parent) { this->parent_ = parent; }
+
+ protected:
+  void write_state(bool state) override;
+
+  WaterFurnaceAurora *parent_{nullptr};
+};
+
+}  // namespace waterfurnace_aurora
+}  // namespace esphome

--- a/components/waterfurnace_aurora/text_sensor/__init__.py
+++ b/components/waterfurnace_aurora/text_sensor/__init__.py
@@ -33,6 +33,26 @@ TEXT_SENSORS = {
     "outputs_at_lockout": DIAGNOSTIC_TEXT_SCHEMA,
     "inputs_at_lockout": DIAGNOSTIC_TEXT_SCHEMA,
     "eev2_ctl": DIAGNOSTIC_TEXT_SCHEMA,
+    # Configuration text sensors (gap 11)
+    "brine_type": DIAGNOSTIC_TEXT_SCHEMA,
+    "flow_meter_type": DIAGNOSTIC_TEXT_SCHEMA,
+    "smartgrid_action": DIAGNOSTIC_TEXT_SCHEMA,
+    "ha_alarm_1_action": DIAGNOSTIC_TEXT_SCHEMA,
+    "ha_alarm_2_action": DIAGNOSTIC_TEXT_SCHEMA,
+    "energy_phase_type": DIAGNOSTIC_TEXT_SCHEMA,
+    # VS Drive 3200-range duplicates (gap 14)
+    "vs_drive_derate_alt": DIAGNOSTIC_TEXT_SCHEMA,
+    "vs_drive_safe_mode_alt": DIAGNOSTIC_TEXT_SCHEMA,
+    "vs_drive_alarm_alt": DIAGNOSTIC_TEXT_SCHEMA,
+    # VS Drive EEV2 Ctl (gap 15)
+    "vs_drive_eev2_ctl": DIAGNOSTIC_TEXT_SCHEMA,
+    # Dealer information (gap 19)
+    "dealer_name": DIAGNOSTIC_TEXT_SCHEMA,
+    "dealer_phone": DIAGNOSTIC_TEXT_SCHEMA,
+    "dealer_address_1": DIAGNOSTIC_TEXT_SCHEMA,
+    "dealer_address_2": DIAGNOSTIC_TEXT_SCHEMA,
+    "dealer_email": DIAGNOSTIC_TEXT_SCHEMA,
+    "dealer_website": DIAGNOSTIC_TEXT_SCHEMA,
 }
 
 CONFIG_SCHEMA = cv.Schema(

--- a/components/waterfurnace_aurora/text_sensor/__init__.py
+++ b/components/waterfurnace_aurora/text_sensor/__init__.py
@@ -32,6 +32,7 @@ TEXT_SENSORS = {
     "lockout_fault_description": DIAGNOSTIC_TEXT_SCHEMA,
     "outputs_at_lockout": DIAGNOSTIC_TEXT_SCHEMA,
     "inputs_at_lockout": DIAGNOSTIC_TEXT_SCHEMA,
+    "eev2_ctl": DIAGNOSTIC_TEXT_SCHEMA,
 }
 
 CONFIG_SCHEMA = cv.Schema(

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -170,6 +170,9 @@ void WaterFurnaceAurora::process_response_() {
     case PendingRequest::POLL_FAULT_HISTORY:
       this->process_fault_history_response_(resp);
       break;
+    case PendingRequest::POLL_DEALER_INFO:
+      this->process_dealer_info_response_(resp);
+      break;
     case PendingRequest::WRITE_SINGLE:
       ESP_LOGD(TAG, "Write acknowledged");
       this->transition_(State::IDLE);
@@ -202,6 +205,11 @@ void WaterFurnaceAurora::handle_timeout_() {
     }
     this->error_backoff_until_ = millis() + ERROR_BACKOFF_MS;
     this->transition_(State::ERROR_BACKOFF);
+  } else if (this->pending_request_ == PendingRequest::POLL_DEALER_INFO) {
+    // Dealer info read failure — not critical, skip
+    ESP_LOGD(TAG, "Dealer info read timed out");
+    this->dealer_info_read_ = true;  // Don't retry
+    this->transition_(State::IDLE);
   } else if (this->pending_request_ == PendingRequest::SETUP_VS_PROBE) {
     // VS probe failure just means no VS drive — continue setup
     ESP_LOGD(TAG, "VS Drive probe timed out — no VS drive");
@@ -975,6 +983,48 @@ void WaterFurnaceAurora::build_poll_addresses_() {
       this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VAPOR_INJECTOR_OPEN;
     }
     
+    // Configuration/settings registers (gap 11) — only poll if at least one is configured
+    if (this->brine_type_sensor_ || this->flow_meter_type_sensor_ || this->smartgrid_action_sensor_ ||
+        this->ha_alarm_1_action_sensor_ || this->ha_alarm_2_action_sensor_ || this->energy_phase_type_sensor_ ||
+        this->off_time_length_sensor_ || this->power_adj_factor_l_sensor_ || this->power_adj_factor_h_sensor_ ||
+        this->smartgrid_trigger_sensor_ || this->ha_alarm_1_trigger_sensor_ || this->ha_alarm_2_trigger_sensor_) {
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::BRINE_TYPE_REG;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::FLOW_METER_TYPE_REG;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SMARTGRID_TRIGGER;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SMARTGRID_ACTION_REG;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::OFF_TIME_LENGTH;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HA_ALARM1_TRIGGER;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HA_ALARM1_ACTION;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HA_ALARM2_TRIGGER;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HA_ALARM2_ACTION;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::ENERGY_PHASE_TYPE_REG;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::POWER_ADJ_FACTOR_L;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::POWER_ADJ_FACTOR_H;
+    }
+
+    // Loop pressure trip and cooling airflow adjustment — poll for number entity read-back
+    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LOOP_PRESSURE_TRIP;
+    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::COOLING_AIRFLOW_ADJUSTMENT;
+
+    // Condensate monitoring (gap 13)
+    if (this->condensate_sensor_) {
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::CONDENSATE;
+    }
+
+    // VS Drive 3200-range duplicates (gap 14) — only poll if any alt sensor is configured
+    if (this->has_vs_drive_ && (this->vs_drive_derate_alt_sensor_ || this->vs_drive_safe_mode_alt_sensor_ ||
+                                 this->vs_drive_alarm_alt_sensor_)) {
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_DERATE_ALT;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_SAFE_MODE_ALT;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_ALARM1_ALT;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_ALARM2_ALT;
+    }
+
+    // VS Drive EEV2 Ctl (gap 15) — only poll if sensor is configured
+    if (this->has_vs_drive_ && this->vs_drive_eev2_ctl_sensor_) {
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_EEV2_CTL;
+    }
+
     // EEV2 diagnostic sensors — only poll if at least one is configured
     if (this->eev_superheat_sensor_ || this->eev_open_sensor_ || this->eev_suction_temperature_sensor_ ||
         this->eev_saturated_suction_temperature_sensor_ || this->eev2_ctl_sensor_) {
@@ -1029,6 +1079,12 @@ void WaterFurnaceAurora::process_poll_response_(const protocol::ParsedResponse &
     return;
   }
   
+  // Dealer info one-shot — if no fault history sensor configured, chain here instead
+  if (!this->dealer_info_read_ && this->has_any_dealer_sensor_()) {
+    this->start_dealer_info_read_();
+    return;
+  }
+
   this->transition_(State::IDLE);
 }
 
@@ -1105,6 +1161,12 @@ void WaterFurnaceAurora::process_fault_history_response_(const protocol::ParsedR
     this->fault_history_sensor_->publish_state(this->cached_fault_history_);
   }
   
+  // Chain dealer info read if any dealer sensor is configured and not yet read
+  if (!this->dealer_info_read_ && this->has_any_dealer_sensor_()) {
+    this->start_dealer_info_read_();
+    return;
+  }
+
   this->transition_(State::IDLE);
 }
 
@@ -1122,6 +1184,7 @@ void WaterFurnaceAurora::publish_all_sensors_() {
   this->publish_power_loop_sensors_(regs);
   this->publish_vs_drive_sensors_(regs);
   this->publish_equipment_sensors_(regs);
+  this->publish_config_sensors_(regs);
   this->publish_humidity_control_sensors_(regs);
   this->publish_iz2_zone_sensors_(regs);
   
@@ -1453,6 +1516,35 @@ void WaterFurnaceAurora::publish_vs_drive_sensors_(const RegisterMap &regs) {
                                       get_vs_alarm_string(*val_a1, *val_a2));
     }
   }
+
+  // VS Drive 3200-range duplicate status strings (gap 14)
+  {
+    const uint16_t *val = reg_find(regs, registers::VS_DRIVE_DERATE_ALT);
+    if (val && *val != this->cached_vs_drive_derate_alt_raw_) {
+      this->cached_vs_drive_derate_alt_raw_ = *val;
+      this->publish_text_if_changed(this->vs_drive_derate_alt_sensor_, this->cached_vs_drive_derate_alt_,
+                                      get_vs_derate_string(*val));
+    }
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::VS_DRIVE_SAFE_MODE_ALT);
+    if (val && *val != this->cached_vs_drive_safe_mode_alt_raw_) {
+      this->cached_vs_drive_safe_mode_alt_raw_ = *val;
+      this->publish_text_if_changed(this->vs_drive_safe_mode_alt_sensor_, this->cached_vs_drive_safe_mode_alt_,
+                                      get_vs_safe_mode_string(*val));
+    }
+  }
+  {
+    const uint16_t *val_a1 = reg_find(regs, registers::VS_DRIVE_ALARM1_ALT);
+    const uint16_t *val_a2 = reg_find(regs, registers::VS_DRIVE_ALARM2_ALT);
+    if (val_a1 && val_a2 &&
+        (*val_a1 != this->cached_vs_drive_alarm1_alt_raw_ || *val_a2 != this->cached_vs_drive_alarm2_alt_raw_)) {
+      this->cached_vs_drive_alarm1_alt_raw_ = *val_a1;
+      this->cached_vs_drive_alarm2_alt_raw_ = *val_a2;
+      this->publish_text_if_changed(this->vs_drive_alarm_alt_sensor_, this->cached_vs_drive_alarm_alt_,
+                                      get_vs_alarm_string(*val_a1, *val_a2));
+    }
+  }
 }
 
 void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
@@ -1536,6 +1628,86 @@ void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
       this->publish_text_if_changed(this->eev2_ctl_sensor_, this->cached_eev2_ctl_,
                                       get_eev2_ctl_string(*val));
     }
+  }
+
+  // VS Drive EEV2 Ctl (gap 15) — same bitmask as register 280
+  {
+    const uint16_t *val = reg_find(regs, registers::VS_DRIVE_EEV2_CTL);
+    if (val && *val != this->cached_vs_drive_eev2_ctl_raw_) {
+      this->cached_vs_drive_eev2_ctl_raw_ = *val;
+      this->publish_text_if_changed(this->vs_drive_eev2_ctl_sensor_, this->cached_vs_drive_eev2_ctl_,
+                                      get_eev2_ctl_string(*val));
+    }
+  }
+
+  // Condensate monitoring (gap 13)
+  this->publish_sensor(regs, registers::CONDENSATE, this->condensate_sensor_);
+}
+
+void WaterFurnaceAurora::publish_config_sensors_(const RegisterMap &regs) {
+  // Configuration text sensors (gap 11) — look up each register once
+  {
+    const uint16_t *val = reg_find(regs, registers::BRINE_TYPE_REG);
+    if (val) this->publish_text_if_changed(this->brine_type_sensor_, this->cached_brine_type_,
+                                            get_brine_type_string(*val));
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::FLOW_METER_TYPE_REG);
+    if (val) this->publish_text_if_changed(this->flow_meter_type_sensor_, this->cached_flow_meter_type_,
+                                            get_flow_meter_type_string(*val));
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::SMARTGRID_ACTION_REG);
+    if (val) this->publish_text_if_changed(this->smartgrid_action_sensor_, this->cached_smartgrid_action_,
+                                            get_smartgrid_action_string(*val));
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::HA_ALARM1_ACTION);
+    if (val) this->publish_text_if_changed(this->ha_alarm_1_action_sensor_, this->cached_ha_alarm_1_action_,
+                                            get_ha_alarm_action_string(*val));
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::HA_ALARM2_ACTION);
+    if (val) this->publish_text_if_changed(this->ha_alarm_2_action_sensor_, this->cached_ha_alarm_2_action_,
+                                            get_ha_alarm_action_string(*val));
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::ENERGY_PHASE_TYPE_REG);
+    if (val) this->publish_text_if_changed(this->energy_phase_type_sensor_, this->cached_energy_phase_type_,
+                                            get_energy_phase_type_string(*val));
+  }
+
+  // Configuration numeric sensors
+  this->publish_sensor(regs, registers::OFF_TIME_LENGTH, this->off_time_length_sensor_);
+  {
+    const uint16_t *val = reg_find(regs, registers::POWER_ADJ_FACTOR_L);
+    if (val && this->power_adj_factor_l_sensor_ != nullptr) {
+      float fval = to_hundredths(*val);
+      if (sensor_value_changed_(this->power_adj_factor_l_sensor_, fval))
+        this->power_adj_factor_l_sensor_->publish_state(fval);
+    }
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::POWER_ADJ_FACTOR_H);
+    if (val && this->power_adj_factor_h_sensor_ != nullptr) {
+      float fval = to_hundredths(*val);
+      if (sensor_value_changed_(this->power_adj_factor_h_sensor_, fval))
+        this->power_adj_factor_h_sensor_->publish_state(fval);
+    }
+  }
+
+  // Configuration binary sensors (open/closed triggers)
+  {
+    const uint16_t *val = reg_find(regs, registers::SMARTGRID_TRIGGER);
+    if (val) publish_binary_if_changed_(this->smartgrid_trigger_sensor_, *val != 0);
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::HA_ALARM1_TRIGGER);
+    if (val) publish_binary_if_changed_(this->ha_alarm_1_trigger_sensor_, *val != 0);
+  }
+  {
+    const uint16_t *val = reg_find(regs, registers::HA_ALARM2_TRIGGER);
+    if (val) publish_binary_if_changed_(this->ha_alarm_2_trigger_sensor_, *val != 0);
   }
 }
 
@@ -1954,6 +2126,22 @@ bool WaterFurnaceAurora::set_test_mode(bool enabled) {
   return true;
 }
 
+bool WaterFurnaceAurora::set_cooling_airflow_adjustment(int16_t value) {
+  // NEGATABLE encoding: negative values stored as 0x10000 + value (two's complement)
+  uint16_t raw = static_cast<uint16_t>(value);
+  ESP_LOGD(TAG, "Setting cooling airflow adjustment to %d (raw 0x%04X)", value, raw);
+  this->write_register(registers::COOLING_AIRFLOW_ADJUSTMENT, raw);
+  return true;
+}
+
+bool WaterFurnaceAurora::set_loop_pressure_trip(float value) {
+  // Register stores value * 10 (inverse of TO_TENTHS)
+  uint16_t raw = static_cast<uint16_t>(value * 10);
+  ESP_LOGD(TAG, "Setting loop pressure trip to %.1f psi (raw %d)", value, raw);
+  this->write_register(registers::LOOP_PRESSURE_TRIP, raw);
+  return true;
+}
+
 bool WaterFurnaceAurora::clear_fault_history() {
   ESP_LOGI(TAG, "Clearing fault history");
   this->write_register(registers::CLEAR_FAULT_HISTORY, registers::CLEAR_FAULT_MAGIC);
@@ -2092,6 +2280,74 @@ void WaterFurnaceAurora::publish_derived_sensors(const RegisterMap &regs) {
         this->approach_temperature_sensor_->publish_state(to_signed_tenths(*val_lw) - sat_cond);
     }
   }
+}
+
+// ============================================================================
+// Dealer Information (gap 19) — one-shot read via func 0x03
+// ============================================================================
+
+void WaterFurnaceAurora::start_dealer_info_read_() {
+  ESP_LOGD(TAG, "Reading dealer information (registers %d-%d)",
+           registers::DEALER_INFO_START,
+           registers::DEALER_INFO_START + registers::DEALER_INFO_COUNT - 1);
+  auto frame = protocol::build_read_holding_request(
+      this->address_, registers::DEALER_INFO_START, registers::DEALER_INFO_COUNT);
+
+  // Build expected address list
+  static uint16_t dealer_addrs[registers::DEALER_INFO_COUNT];
+  static bool dealer_addrs_init = false;
+  if (!dealer_addrs_init) {
+    for (uint16_t i = 0; i < registers::DEALER_INFO_COUNT; i++) {
+      dealer_addrs[i] = registers::DEALER_INFO_START + i;
+    }
+    dealer_addrs_init = true;
+  }
+
+  this->send_request_(frame, PendingRequest::POLL_DEALER_INFO,
+                      dealer_addrs, registers::DEALER_INFO_COUNT);
+}
+
+void WaterFurnaceAurora::process_dealer_info_response_(const protocol::ParsedResponse &resp) {
+  // Extract multi-register strings from response.
+  // Each string field starts at a known register and spans N registers.
+  struct DealerField {
+    uint16_t start;
+    uint16_t count;
+    text_sensor::TextSensor *sensor;
+    std::string *cached;
+  };
+  DealerField fields[] = {
+    {registers::DEALER_NAME, 13, this->dealer_name_sensor_, &this->cached_dealer_name_},
+    {registers::DEALER_PHONE, 8, this->dealer_phone_sensor_, &this->cached_dealer_phone_},
+    {registers::DEALER_ADDRESS1, 13, this->dealer_address_1_sensor_, &this->cached_dealer_address_1_},
+    {registers::DEALER_ADDRESS2, 13, this->dealer_address_2_sensor_, &this->cached_dealer_address_2_},
+    {registers::DEALER_EMAIL, 13, this->dealer_email_sensor_, &this->cached_dealer_email_},
+    {registers::DEALER_WEBSITE, 13, this->dealer_website_sensor_, &this->cached_dealer_website_},
+  };
+
+  for (auto &field : fields) {
+    if (field.sensor == nullptr) continue;
+    // Collect consecutive register values into a stack buffer
+    uint16_t buf[13];  // Max field length
+    size_t buf_count = 0;
+    for (uint16_t i = 0; i < field.count && i < 13; i++) {
+      // Search response registers for this address
+      for (const auto &rv : resp.registers) {
+        if (rv.address == field.start + i) {
+          buf[buf_count++] = rv.value;
+          break;
+        }
+      }
+    }
+    if (buf_count > 0) {
+      std::string str = registers_to_string(buf, buf_count);
+      this->publish_text_if_changed(field.sensor, *field.cached, str);
+    }
+  }
+
+  this->dealer_info_read_ = true;
+  ESP_LOGD(TAG, "Dealer info read complete");
+  this->transition_(State::IDLE);
 }
 
 // ============================================================================

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -153,7 +153,10 @@ void WaterFurnaceAurora::process_response_() {
   this->status_clear_warning();
   this->status_clear_error();
   
-  // Route to appropriate handler
+  // Route to appropriate handler.
+  // Handlers may chain to a new request (e.g. poll → fault history → dealer info).
+  // Only clear pending_request_ if the handler did NOT chain — detected by the
+  // state still being WAITING_RESPONSE (chained requests transition to TX_PENDING).
   switch (this->pending_request_) {
     case PendingRequest::SETUP_ID:
       this->process_setup_id_response_(resp);
@@ -185,7 +188,14 @@ void WaterFurnaceAurora::process_response_() {
       break;
   }
   
-  this->pending_request_ = PendingRequest::NONE;
+  // Only clear pending_request_ if the handler did NOT chain to a new request.
+  // Chained requests (fault history, dealer info, medium poll) call send_request_()
+  // which transitions state to TX_PENDING and sets pending_request_ to the new type.
+  // Clearing it here would clobber the new request, causing the response to be
+  // silently discarded by the default case above.
+  if (this->state_ != State::TX_PENDING) {
+    this->pending_request_ = PendingRequest::NONE;
+  }
 }
 
 void WaterFurnaceAurora::handle_timeout_() {

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -210,7 +210,7 @@ void WaterFurnaceAurora::handle_timeout_() {
     this->transition_(State::ERROR_BACKOFF);
   } else if (this->pending_request_ == PendingRequest::POLL_FAULT_HISTORY) {
     // Fault history read failure — not critical, skip this cycle
-    ESP_LOGD(TAG, "Fault history read timed out");
+    ESP_LOGW(TAG, "Fault history read timed out (no response from ABC for func 0x41)");
     // Chain to dealer info if needed, otherwise go idle
     if (!this->dealer_info_read_ && this->has_any_dealer_sensor_()) {
       this->start_dealer_info_read_();
@@ -1145,6 +1145,12 @@ void WaterFurnaceAurora::finish_poll_cycle_() {
   
   // Check if we need fault history this cycle
   bool slow_poll = (this->poll_tier_counter_ % 60) == 0;
+  if (slow_poll) {
+    ESP_LOGD(TAG, "Slow tier cycle %d: fault_sensor=%s, fault_counters=%s",
+             this->poll_tier_counter_,
+             this->fault_history_sensor_ != nullptr ? "yes" : "no",
+             this->has_any_fault_counter_sensor_ ? "yes" : "no");
+  }
   if (slow_poll && (this->fault_history_sensor_ != nullptr || this->has_any_fault_counter_sensor_)) {
     this->start_fault_history_read_();
     return;
@@ -1160,6 +1166,7 @@ void WaterFurnaceAurora::finish_poll_cycle_() {
 }
 
 void WaterFurnaceAurora::start_fault_history_read_() {
+  ESP_LOGD(TAG, "Starting fault history read (func 0x41, regs 601-699)");
   // Ruby gem reads 601..699 via func 0x41 (read contiguous ranges).
   // The ABC board does not respond to func 0x03 for this register range.
   auto frame = protocol::build_read_ranges_request(
@@ -1180,6 +1187,7 @@ void WaterFurnaceAurora::start_fault_history_read_() {
 }
 
 void WaterFurnaceAurora::process_fault_history_response_(const protocol::ParsedResponse &resp) {
+  ESP_LOGD(TAG, "Fault history response received (%d register values)", resp.registers.size());
   // Publish individual fault counters (E1-E99)
   // Each register value is the count of how many times that fault occurred.
   // Register 601 = E1, 602 = E2, ..., 699 = E99.

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -2366,22 +2366,29 @@ void WaterFurnaceAurora::publish_derived_sensors(const RegisterMap &regs) {
     }
   }
   
-  // Approach temperature — only meaningful when the compressor is running.
-  // When idle, the saturated condenser register holds stale values that produce
-  // nonsensical results (e.g., -40°F).
+  // Approach temperature — condenser approach, only meaningful when compressor is running.
+  // In cooling: condenser is water-side HX → approach = sat_cond - EWT
+  // In heating: condenser is indoor air coil → approach = sat_cond - leaving_air (reg 900)
+  //   Leaving air requires AWL AXB; on non-AXB systems, heating approach is NAN.
   if (this->approach_temperature_sensor_ != nullptr) {
     bool compressor_on = (this->system_outputs_ & (OUTPUT_CC | OUTPUT_CC2)) != 0;
     if (compressor_on) {
-      const uint16_t *val_lw = reg_find(regs, registers::LEAVING_WATER);
-      const uint16_t *val_ew = reg_find(regs, registers::ENTERING_WATER);
       const uint16_t *val_sc = reg_find(regs, registers::SATURATED_CONDENSER_TEMP);
       if (val_sc) {
         float sat_cond = to_signed_tenths(*val_sc);
         bool cooling = (this->system_outputs_ & OUTPUT_RV) != 0;
-        if (cooling && val_ew)
-          this->approach_temperature_sensor_->publish_state(sat_cond - to_signed_tenths(*val_ew));
-        else if (!cooling && val_lw)
-          this->approach_temperature_sensor_->publish_state(sat_cond - to_signed_tenths(*val_lw));
+        if (cooling) {
+          const uint16_t *val_ew = reg_find(regs, registers::ENTERING_WATER);
+          if (val_ew)
+            this->approach_temperature_sensor_->publish_state(sat_cond - to_signed_tenths(*val_ew));
+        } else {
+          // Heating: condenser is air-side, use leaving air temp (register 900, requires AXB)
+          const uint16_t *val_la = reg_find(regs, registers::LEAVING_AIR);
+          if (val_la)
+            this->approach_temperature_sensor_->publish_state(sat_cond - to_signed_tenths(*val_la));
+          else if (sensor_value_changed_(this->approach_temperature_sensor_, NAN))
+            this->approach_temperature_sensor_->publish_state(NAN);  // No AXB, no supply air
+        }
       }
     } else if (sensor_value_changed_(this->approach_temperature_sensor_, NAN)) {
       this->approach_temperature_sensor_->publish_state(NAN);

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -118,7 +118,9 @@ bool WaterFurnaceAurora::read_frame_() {
   
   // Validate CRC
   if (!protocol::validate_frame_crc(this->response_frame_.data(), this->response_frame_len_)) {
-    ESP_LOGW(TAG, "CRC mismatch in response (%d bytes)", this->response_frame_len_);
+    ESP_LOGW(TAG, "CRC mismatch in response (%d bytes, func=0x%02X)",
+             this->response_frame_len_,
+             this->response_frame_len_ >= 2 ? this->response_frame_[1] : 0xFF);
     this->status_set_warning(LOG_STR("CRC mismatch in Modbus response"));
     return false;
   }
@@ -199,8 +201,24 @@ void WaterFurnaceAurora::process_response_() {
 }
 
 void WaterFurnaceAurora::handle_timeout_() {
-  ESP_LOGW(TAG, "Response timeout for request type %d (rx_buf=%d bytes)",
-           static_cast<int>(this->pending_request_), this->rx_buffer_len_);
+  // Log first 16 bytes of buffer as hex for remote diagnosis if present
+  if (this->rx_buffer_len_ > 0) {
+    char hex[49];  // 16 bytes * 3 chars + null
+    size_t n = std::min(this->rx_buffer_len_, static_cast<size_t>(16));
+    for (size_t i = 0; i < n; i++) {
+      snprintf(hex + i * 3, 4, "%02X ", this->rx_buffer_[i]);
+    }
+    hex[n * 3 - 1] = '\0';  // trim trailing space
+    
+    size_t expected = protocol::expected_frame_size(this->rx_buffer_.data(), this->rx_buffer_len_);
+    ESP_LOGW(TAG, "Response timeout for request type %d (rx_buf=%d bytes: %s)",
+             static_cast<int>(this->pending_request_), this->rx_buffer_len_, hex);
+    ESP_LOGW(TAG, "  expected_frame_size=%d", expected);
+  } else {
+    ESP_LOGW(TAG, "Response timeout for request type %d (rx_buf=0 bytes)",
+             static_cast<int>(this->pending_request_));
+  }
+
   this->rx_buffer_len_ = 0;
   
   // During setup, use retry/backoff
@@ -208,7 +226,8 @@ void WaterFurnaceAurora::handle_timeout_() {
       this->pending_request_ == PendingRequest::SETUP_DETECT) {
     this->setup_retry_count_++;
     if (this->setup_retry_count_ >= MAX_SETUP_RETRIES) {
-      ESP_LOGW(TAG, "Setup failed after %d retries — will continue with defaults", MAX_SETUP_RETRIES);
+      ESP_LOGW(TAG, "Setup failed after %d retries — will re-detect when heat pump responds", MAX_SETUP_RETRIES);
+      this->needs_redetect_ = true;
       // Deliberately NOT calling mark_failed() here: the heat pump may come online
       // later, so we degrade gracefully with default config rather than permanently
       // disabling the component.  status_set_error() surfaces the issue in the UI.
@@ -1078,6 +1097,13 @@ void WaterFurnaceAurora::start_poll_cycle_() {
     ESP_LOGD(TAG, "No registers to poll");
     return;
   }
+
+  // Bounds check: if address list overflowed (should be caught by add_poll_addr_ but safe > sorry)
+  if (this->addresses_to_read_len_ > MAX_POLL_ADDRESSES) {
+    ESP_LOGW(TAG, "Poll address list overflow: %d > %d (truncating)",
+             this->addresses_to_read_len_, MAX_POLL_ADDRESSES);
+    this->addresses_to_read_len_ = MAX_POLL_ADDRESSES;
+  }
   
   // The ABC board limits reads to 100 registers per request.
   // When the combined fast + medium tier exceeds this limit, we send only
@@ -1093,8 +1119,10 @@ void WaterFurnaceAurora::start_poll_cycle_() {
     return;
   }
   
-  ESP_LOGV(TAG, "Poll: %d total addresses, sending batch 1 of %d",
-           this->addresses_to_read_len_, first_batch);
+  ESP_LOGD(TAG, "Poll: %d total addresses%s, sending batch 1 of %d",
+           this->addresses_to_read_len_,
+           (this->poll_tier_counter_ % 6 == 0) ? " (medium tier)" : "",
+           first_batch);
   
   this->send_request_(frame, PendingRequest::POLL_REGISTERS,
                       this->addresses_to_read_.data(), first_batch);
@@ -1123,6 +1151,21 @@ void WaterFurnaceAurora::process_poll_response_(const protocol::ParsedResponse &
   // Successful poll — reset retry counter.
   this->poll_retry_count_ = 0;
   
+  // First successful poll after a failed setup — trigger hardware re-detection
+  if (this->needs_redetect_) {
+    this->needs_redetect_ = false;
+    this->setup_complete_ = false;  // Temporarily allow setup states
+    this->setup_retry_count_ = 0;
+    ESP_LOGI(TAG, "Heat pump responded — re-running hardware detection");
+
+    // Merge what we got so far (may help with partial detection)
+    for (const auto &rv : resp.registers) {
+      reg_insert(this->register_cache_, rv.address, rv.value);
+    }
+    this->transition_(State::SETUP_READ_ID);
+    return;
+  }
+
   // Merge response directly into cache — no intermediate allocation.
   // reg_insert() handles insert-or-update in the sorted vector.
   for (const auto &rv : resp.registers) {

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -1278,8 +1278,10 @@ void WaterFurnaceAurora::publish_system_status_sensors_(const RegisterMap &regs)
     const uint16_t *val = reg_find(regs, registers::SYSTEM_STATUS);
     if (val) {
       uint16_t status = *val;
-      publish_binary_if_changed_(this->low_pressure_switch_sensor_, (status & STATUS_LPS) != 0);
-      publish_binary_if_changed_(this->high_pressure_switch_sensor_, (status & STATUS_HPS) != 0);
+      // Pressure switch bits: SET = closed (normal), CLEAR = open (fault).
+      // Binary sensors use device_class PROBLEM, so true = problem = switch open.
+      publish_binary_if_changed_(this->low_pressure_switch_sensor_, (status & STATUS_LPS) == 0);
+      publish_binary_if_changed_(this->high_pressure_switch_sensor_, (status & STATUS_HPS) == 0);
       publish_binary_if_changed_(this->emergency_shutdown_sensor_,
                                  (status & STATUS_EMERGENCY_SHUTDOWN) != 0);
       publish_binary_if_changed_(this->load_shed_sensor_, (status & STATUS_LOAD_SHED) != 0);
@@ -1334,10 +1336,30 @@ void WaterFurnaceAurora::publish_temperature_sensors_(const RegisterMap &regs) {
     }
   }
   
-  uint16_t entering_air_reg = this->awl_axb() ? registers::ENTERING_AIR_AWL : registers::ENTERING_AIR;
-  this->publish_sensor_signed_tenths(regs, entering_air_reg, this->entering_air_temperature_sensor_);
+  // Entering air (return air) — suppress zero readings (register returns 0 when
+  // the sensor is absent or the system is not AWL-communicating).  The Ruby gem
+  // does: `unless entering_air_temperature.zero?`
+  {
+    uint16_t entering_air_reg = this->awl_axb() ? registers::ENTERING_AIR_AWL : registers::ENTERING_AIR;
+    const uint16_t *val = reg_find(regs, entering_air_reg);
+    if (val && *val != 0) {
+      float fval = to_signed_tenths(*val);
+      if (sensor_value_changed_(this->entering_air_temperature_sensor_, fval))
+        this->entering_air_temperature_sensor_->publish_state(fval);
+    }
+  }
   this->publish_sensor_signed_tenths(regs, registers::LEAVING_AIR, this->leaving_air_temperature_sensor_);
-  this->publish_sensor_signed_tenths(regs, registers::OUTDOOR_TEMP, this->outdoor_temperature_sensor_);
+  // Outdoor temperature — suppress zero readings (register returns 0 when the
+  // system is not AWL-communicating).  The Ruby gem does:
+  // `if awl_communicating? && !outdoor_temperature.zero?`
+  {
+    const uint16_t *val = reg_find(regs, registers::OUTDOOR_TEMP);
+    if (val && *val != 0) {
+      float fval = to_signed_tenths(*val);
+      if (sensor_value_changed_(this->outdoor_temperature_sensor_, fval))
+        this->outdoor_temperature_sensor_->publish_state(fval);
+    }
+  }
   this->publish_sensor_signed_tenths(regs, registers::LEAVING_WATER, this->leaving_water_temperature_sensor_);
   this->publish_sensor_signed_tenths(regs, registers::ENTERING_WATER, this->entering_water_temperature_sensor_);
   
@@ -2266,18 +2288,25 @@ void WaterFurnaceAurora::publish_derived_sensors(const RegisterMap &regs) {
     }
   }
   
-  // Approach temperature
+  // Approach temperature — only meaningful when the compressor is running.
+  // When idle, the saturated condenser register holds stale values that produce
+  // nonsensical results (e.g., -40°F).
   if (this->approach_temperature_sensor_ != nullptr) {
-    const uint16_t *val_lw = reg_find(regs, registers::LEAVING_WATER);
-    const uint16_t *val_ew = reg_find(regs, registers::ENTERING_WATER);
-    const uint16_t *val_sc = reg_find(regs, registers::SATURATED_CONDENSER_TEMP);
-    if (val_sc) {
-      float sat_cond = to_signed_tenths(*val_sc);
-      bool cooling = (this->system_outputs_ & OUTPUT_RV) != 0;
-      if (cooling && val_ew)
-        this->approach_temperature_sensor_->publish_state(sat_cond - to_signed_tenths(*val_ew));
-      else if (!cooling && val_lw)
-        this->approach_temperature_sensor_->publish_state(to_signed_tenths(*val_lw) - sat_cond);
+    bool compressor_on = (this->system_outputs_ & (OUTPUT_CC | OUTPUT_CC2)) != 0;
+    if (compressor_on) {
+      const uint16_t *val_lw = reg_find(regs, registers::LEAVING_WATER);
+      const uint16_t *val_ew = reg_find(regs, registers::ENTERING_WATER);
+      const uint16_t *val_sc = reg_find(regs, registers::SATURATED_CONDENSER_TEMP);
+      if (val_sc) {
+        float sat_cond = to_signed_tenths(*val_sc);
+        bool cooling = (this->system_outputs_ & OUTPUT_RV) != 0;
+        if (cooling && val_ew)
+          this->approach_temperature_sensor_->publish_state(sat_cond - to_signed_tenths(*val_ew));
+        else if (!cooling && val_lw)
+          this->approach_temperature_sensor_->publish_state(to_signed_tenths(*val_lw) - sat_cond);
+      }
+    } else if (sensor_value_changed_(this->approach_temperature_sensor_, NAN)) {
+      this->approach_temperature_sensor_->publish_state(NAN);
     }
   }
 }

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -437,9 +437,9 @@ void WaterFurnaceAurora::dump_config() {
 const IZ2ZoneData& WaterFurnaceAurora::get_zone_data(uint8_t zone_number) const {
   if (zone_number < 1 || zone_number > MAX_IZ2_ZONES) {
     ESP_LOGW(TAG, "Invalid zone_number %d in get_zone_data (expected 1-%d)", zone_number, MAX_IZ2_ZONES);
-    return iz2_zones_[0];
+    return this->iz2_zones_[0];
   }
-  return iz2_zones_[zone_number - 1];
+  return this->iz2_zones_[zone_number - 1];
 }
 
 bool WaterFurnaceAurora::validate_zone_number(uint8_t zone_number) const {
@@ -963,6 +963,27 @@ void WaterFurnaceAurora::build_poll_addresses_() {
       this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HUMIDISTAT_SETTINGS;
       this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HUMIDISTAT_TARGETS;
     }
+    
+    // AXB diagnostic sensors — only poll if at least one is configured
+    if (this->has_axb_ && (this->axb_leaving_air_temperature_sensor_ || this->axb_suction_temperature_sensor_ ||
+                           this->saturated_evaporator_temperature_sensor_ || this->axb_superheat_sensor_ ||
+                           this->vapor_injector_open_sensor_)) {
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_LEAVING_AIR_TEMP;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_SUCTION_TEMP;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SATURATED_EVAPORATOR_TEMP;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_SUPERHEAT;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VAPOR_INJECTOR_OPEN;
+    }
+    
+    // EEV2 diagnostic sensors — only poll if at least one is configured
+    if (this->eev_superheat_sensor_ || this->eev_open_sensor_ || this->eev_suction_temperature_sensor_ ||
+        this->eev_saturated_suction_temperature_sensor_ || this->eev2_ctl_sensor_) {
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV2_CTL;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV_SUPERHEAT;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV_OPEN;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV_SUCTION_TEMP;
+      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV_SATURATED_SUCTION_TEMP;
+    }
   }
 }
 
@@ -1003,7 +1024,7 @@ void WaterFurnaceAurora::process_poll_response_(const protocol::ParsedResponse &
   
   // Check if we need fault history this cycle
   bool slow_poll = (this->poll_tier_counter_ % 60) == 0;
-  if (slow_poll && this->fault_history_sensor_ != nullptr) {
+  if (slow_poll && (this->fault_history_sensor_ != nullptr || this->has_any_fault_counter_sensor_)) {
     this->start_fault_history_read_();
     return;
   }
@@ -1029,46 +1050,61 @@ void WaterFurnaceAurora::start_fault_history_read_() {
 }
 
 void WaterFurnaceAurora::process_fault_history_response_(const protocol::ParsedResponse &resp) {
-  if (this->fault_history_sensor_ == nullptr) {
-    this->transition_(State::IDLE);
-    return;
-  }
-  
-  // Reuse cached string to avoid heap allocation on every slow-tier cycle (~5min).
-  // clear() preserves the existing buffer capacity (reserved to 256 in setup()).
-  this->cached_fault_history_.clear();
-  int fault_count = 0;
-  const int max_faults = 10;
-  
-  for (const auto &rv : resp.registers) {
-    if (fault_count >= max_faults) break;
-    if (rv.value == 0 || rv.value == 0xFFFF) continue;
-    
-    uint8_t fault_code = rv.value % 100;
-    if (fault_code == 0) continue;
-    
-    if (!this->cached_fault_history_.empty()) this->cached_fault_history_ += "; ";
-    this->cached_fault_history_ += "E";
-    char code_buf[4];
-    snprintf(code_buf, sizeof(code_buf), "%u", fault_code);
-    this->cached_fault_history_ += code_buf;
-    
-    const char *desc = get_fault_description(fault_code);
-    if (desc && strcmp(desc, "Unknown Fault") != 0) {
-      this->cached_fault_history_ += " (";
-      this->cached_fault_history_ += desc;
-      this->cached_fault_history_ += ")";
+  // Publish individual fault counters (E1-E99)
+  // Each register value is the count of how many times that fault occurred.
+  // Register 601 = E1, 602 = E2, ..., 699 = E99.
+  if (this->has_any_fault_counter_sensor_) {
+    for (const auto &rv : resp.registers) {
+      if (rv.address < registers::FAULT_HISTORY_START || rv.address > registers::FAULT_HISTORY_END)
+        continue;
+      uint8_t idx = static_cast<uint8_t>(rv.address - registers::FAULT_HISTORY_START);
+      if (idx >= FAULT_COUNTER_COUNT) continue;
+      sensor::Sensor *sens = this->fault_counter_sensors_[idx];
+      if (sens == nullptr) continue;
+      float fval = static_cast<float>(rv.value);
+      if (sensor_value_changed_(sens, fval))
+        sens->publish_state(fval);
     }
-    fault_count++;
+  }
+
+  if (this->fault_history_sensor_ != nullptr) {
+    // Reuse cached string to avoid heap allocation on every slow-tier cycle (~5min).
+    // clear() preserves the existing buffer capacity (reserved to 256 in setup()).
+    this->cached_fault_history_.clear();
+    int fault_count = 0;
+    const int max_faults = 10;
+    
+    for (const auto &rv : resp.registers) {
+      if (fault_count >= max_faults) break;
+      if (rv.value == 0 || rv.value == 0xFFFF) continue;
+      
+      uint8_t fault_code = rv.value % 100;
+      if (fault_code == 0) continue;
+      
+      if (!this->cached_fault_history_.empty()) this->cached_fault_history_ += "; ";
+      this->cached_fault_history_ += "E";
+      char code_buf[4];
+      snprintf(code_buf, sizeof(code_buf), "%u", fault_code);
+      this->cached_fault_history_ += code_buf;
+      
+      const char *desc = get_fault_description(fault_code);
+      if (desc && strcmp(desc, "Unknown Fault") != 0) {
+        this->cached_fault_history_ += " (";
+        this->cached_fault_history_ += desc;
+        this->cached_fault_history_ += ")";
+      }
+      fault_count++;
+    }
+    
+    if (this->cached_fault_history_.empty()) {
+      this->cached_fault_history_ = "No faults";
+    } else if (fault_count >= max_faults) {
+      this->cached_fault_history_ += "...";
+    }
+    
+    this->fault_history_sensor_->publish_state(this->cached_fault_history_);
   }
   
-  if (this->cached_fault_history_.empty()) {
-    this->cached_fault_history_ = "No faults";
-  } else if (fault_count >= max_faults) {
-    this->cached_fault_history_ += "...";
-  }
-  
-  this->fault_history_sensor_->publish_state(this->cached_fault_history_);
   this->transition_(State::IDLE);
 }
 
@@ -1480,6 +1516,27 @@ void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
   
   this->publish_sensor_int32(regs, registers::HEAT_OF_EXTRACTION, this->heat_of_extraction_sensor_);
   this->publish_sensor_int32(regs, registers::HEAT_OF_REJECTION, this->heat_of_rejection_sensor_);
+  
+  // AXB diagnostic sensors (medium tier)
+  this->publish_sensor_signed_tenths(regs, registers::AXB_LEAVING_AIR_TEMP, this->axb_leaving_air_temperature_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::AXB_SUCTION_TEMP, this->axb_suction_temperature_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::SATURATED_EVAPORATOR_TEMP, this->saturated_evaporator_temperature_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::AXB_SUPERHEAT, this->axb_superheat_sensor_);
+  this->publish_sensor(regs, registers::VAPOR_INJECTOR_OPEN, this->vapor_injector_open_sensor_);
+  
+  // EEV2 sensors (medium tier)
+  this->publish_sensor_signed_tenths(regs, registers::EEV_SUPERHEAT, this->eev_superheat_sensor_);
+  this->publish_sensor(regs, registers::EEV_OPEN, this->eev_open_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::EEV_SUCTION_TEMP, this->eev_suction_temperature_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::EEV_SATURATED_SUCTION_TEMP, this->eev_saturated_suction_temperature_sensor_);
+  {
+    const uint16_t *val = reg_find(regs, registers::EEV2_CTL);
+    if (val && *val != this->cached_eev2_ctl_raw_) {
+      this->cached_eev2_ctl_raw_ = *val;
+      this->publish_text_if_changed(this->eev2_ctl_sensor_, this->cached_eev2_ctl_,
+                                      get_eev2_ctl_string(*val));
+    }
+  }
 }
 
 void WaterFurnaceAurora::publish_humidity_control_sensors_(const RegisterMap &regs) {
@@ -1856,6 +1913,44 @@ bool WaterFurnaceAurora::set_dehumidifier_mode(bool auto_mode) {
   ESP_LOGI(TAG, "Setting dehumidifier mode to %s (reg %d = 0x%04X)", auto_mode ? "Auto" : "Manual", write_reg, raw_value);
   this->write_register(write_reg, raw_value);
   this->dehumidifier_auto_ = auto_mode;
+  return true;
+}
+
+bool WaterFurnaceAurora::set_manual_operation(uint8_t mode, uint8_t compressor_speed,
+                                               uint8_t blower_speed, bool aux_heat) {
+  if (compressor_speed > 15) { ESP_LOGW(TAG, "Manual compressor speed %d out of range (0-15)", compressor_speed); return false; }
+  if (blower_speed > 15 && blower_speed != 255) { ESP_LOGW(TAG, "Manual blower speed %d out of range (0-15 or 255=auto)", blower_speed); return false; }
+  if (mode > 2) { ESP_LOGW(TAG, "Manual mode %d out of range (0=off, 1=heat, 2=cool)", mode); return false; }
+  
+  if (mode == 0) {
+    return this->set_manual_operation_off();
+  }
+  
+  // Build bitmask per Ruby gem abc_client.rb:307-332
+  uint16_t value = 0;
+  value |= (compressor_speed & 0x0F);
+  value |= (blower_speed == 255) ? registers::MANUAL_BLOWER_WITH_COMPRESSOR
+                                  : static_cast<uint16_t>((blower_speed & 0x0F) << 4);
+  if (mode == 2) value |= registers::MANUAL_OPERATION_COOLING;
+  if (aux_heat) value |= registers::MANUAL_OPERATION_AUX_HEAT;
+  
+  ESP_LOGI(TAG, "Setting manual operation: mode=%s compressor=%d blower=%s%s (reg 3002=0x%04X)",
+           mode == 2 ? "cooling" : "heating", compressor_speed,
+           blower_speed == 255 ? "auto" : "manual",
+           aux_heat ? " +aux" : "", value);
+  this->write_register(registers::MANUAL_OPERATION, value);
+  return true;
+}
+
+bool WaterFurnaceAurora::set_manual_operation_off() {
+  ESP_LOGI(TAG, "Turning off manual operation");
+  this->write_register(registers::MANUAL_OPERATION, registers::MANUAL_OPERATION_OFF);
+  return true;
+}
+
+bool WaterFurnaceAurora::set_test_mode(bool enabled) {
+  ESP_LOGI(TAG, "%s test mode", enabled ? "Enabling" : "Disabling");
+  this->write_register(registers::TEST_MODE, enabled ? 1 : 0);
   return true;
 }
 

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -1155,12 +1155,6 @@ void WaterFurnaceAurora::finish_poll_cycle_() {
   
   // Check if we need fault history this cycle
   bool slow_poll = (this->poll_tier_counter_ % 60) == 0;
-  if (slow_poll) {
-    ESP_LOGD(TAG, "Slow tier cycle %d: fault_sensor=%s, fault_counters=%s",
-             this->poll_tier_counter_,
-             this->fault_history_sensor_ != nullptr ? "yes" : "no",
-             this->has_any_fault_counter_sensor_ ? "yes" : "no");
-  }
   if (slow_poll && (this->fault_history_sensor_ != nullptr || this->has_any_fault_counter_sensor_)) {
     this->start_fault_history_read_();
     return;

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -405,6 +405,17 @@ void WaterFurnaceAurora::dump_config() {
     ESP_LOGCONFIG(TAG, "  IZ2 Zones: %d%s", this->num_iz2_zones_,
                   this->iz2_zones_override_ ? " (override)" : "");
   }
+  ESP_LOGCONFIG(TAG, "  DIP Switches: fp1=%d fp2=%d rv=%s acc=%d stages=%d lockout=%s dh_rh=%s%s",
+                this->dip_switches_.fp1, this->dip_switches_.fp2,
+                this->dip_switches_.reversing_valve == ReversingValveType::O_TYPE ? "O" : "B",
+                static_cast<int>(this->dip_switches_.accessory_relay),
+                this->dip_switches_.compressor_stages,
+                this->dip_switches_.lockout == LockoutType::CONTINUOUS ? "continuous" : "pulse",
+                this->dip_switches_.dehumidifier_reheat == DehumidifierReheat::DEHUMIDIFIER ? "dehumidifier" : "reheat",
+                this->dip_switches_.manual ? " (MANUAL)" : "");
+  ESP_LOGCONFIG(TAG, "  Humidifier: %s, Dehumidifier: %s",
+                this->has_humidifier_ ? "yes" : "no",
+                this->has_dehumidifier_ ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  Blower: %s", this->blower_type_ == BlowerType::PSC ? "PSC" :
                 this->blower_type_ == BlowerType::FIVE_SPEED ? "5-Speed" : "ECM");
   ESP_LOGCONFIG(TAG, "  Pump: %s", get_pump_type_string(this->pump_type_));
@@ -511,9 +522,11 @@ void WaterFurnaceAurora::start_setup_detect_() {
   if (!this->iz2_override_) addrs[addrs_len++] = registers::IZ2_INSTALLED;
   addrs[addrs_len++] = registers::IZ2_VERSION;
   if (!this->iz2_zones_override_) addrs[addrs_len++] = registers::IZ2_NUM_ZONES;
+  addrs[addrs_len++] = registers::DIP_SWITCH_STATUS;
   addrs[addrs_len++] = registers::BLOWER_TYPE;
   addrs[addrs_len++] = registers::ENERGY_MONITOR;
   addrs[addrs_len++] = registers::PUMP_TYPE;
+  addrs[addrs_len++] = registers::AXB_INPUTS;  // For AXB accessory relay 2 detection
   
   if (!this->vs_drive_override_) {
     addrs[addrs_len++] = registers::ABC_PROGRAM;      // ABC program version (4 regs)
@@ -583,6 +596,23 @@ void WaterFurnaceAurora::process_setup_detect_response_(const protocol::ParsedRe
   const uint16_t *val_iver = reg_find(result, registers::IZ2_VERSION);
   if (val_iver) this->iz2_version_ = static_cast<float>(*val_iver) / 100.0f;
   
+  // DIP Switch settings (register 33) — used for compressor stages, humidifier detection
+  // Matches Ruby gem abc_client.rb:179 — @abc_dipswitches = registers[33]
+  {
+    const uint16_t *val_dip = reg_find(result, registers::DIP_SWITCH_STATUS);
+    if (val_dip) {
+      this->dip_switches_ = parse_dip_switches(*val_dip);
+      ESP_LOGD(TAG, "DIP switches: fp1=%d, fp2=%d, rv=%s, acc=%d, comp_stages=%d, lockout=%s, dh_rh=%s%s",
+               this->dip_switches_.fp1, this->dip_switches_.fp2,
+               this->dip_switches_.reversing_valve == ReversingValveType::O_TYPE ? "O" : "B",
+               static_cast<int>(this->dip_switches_.accessory_relay),
+               this->dip_switches_.compressor_stages,
+               this->dip_switches_.lockout == LockoutType::CONTINUOUS ? "continuous" : "pulse",
+               this->dip_switches_.dehumidifier_reheat == DehumidifierReheat::DEHUMIDIFIER ? "dehumidifier" : "reheat",
+               this->dip_switches_.manual ? " (MANUAL)" : "");
+    }
+  }
+
   // Blower type
   const uint16_t *val_blower = reg_find(result, registers::BLOWER_TYPE);
   if (val_blower) {
@@ -609,6 +639,20 @@ void WaterFurnaceAurora::process_setup_detect_response_(const protocol::ParsedRe
     this->pump_type_ = (pval <= 7) ? static_cast<PumpType>(pval) : PumpType::OTHER;
   }
   
+  // Humidistat presence detection — matches Ruby gem abc_client.rb:201-204.
+  // Humidifier: ABC DIP switch accessory_relay == HUMIDIFIER
+  // Dehumidifier: AXB present AND AXB inputs accessory_relay2 == DEHUMIDIFIER
+  this->has_humidifier_ = (this->dip_switches_.accessory_relay == AccessoryRelay::HUMIDIFIER);
+  if (this->has_axb_) {
+    const uint16_t *val_axb_in = reg_find(result, registers::AXB_INPUTS);
+    if (val_axb_in) {
+      this->has_dehumidifier_ = (axb_extract_accessory_relay2(*val_axb_in) == AxbAccessoryRelay2::DEHUMIDIFIER);
+    }
+  }
+  ESP_LOGD(TAG, "Humidistat: humidifier=%s, dehumidifier=%s",
+           this->has_humidifier_ ? "yes" : "no",
+           this->has_dehumidifier_ ? "yes" : "no");
+
   // VS Drive detection via ABC program
   bool vs_detected_from_program = false;
   if (!this->vs_drive_override_) {
@@ -701,6 +745,9 @@ void WaterFurnaceAurora::finish_setup_() {
            this->blower_type_ == BlowerType::PSC ? "PSC" :
            this->blower_type_ == BlowerType::FIVE_SPEED ? "5-Speed" : "ECM",
            get_pump_type_string(this->pump_type_), this->energy_monitor_level_);
+  ESP_LOGI(TAG, "  Humidifier: %s, Dehumidifier: %s",
+           this->has_humidifier_ ? "yes" : "no",
+           this->has_dehumidifier_ ? "yes" : "no");
   
   // Fire deferred setup callbacks
   for (size_t i = 0; i < this->setup_callbacks_len_; i++) {
@@ -1298,8 +1345,22 @@ void WaterFurnaceAurora::publish_power_loop_sensors_(const RegisterMap &regs) {
 }
 
 void WaterFurnaceAurora::publish_vs_drive_sensors_(const RegisterMap &regs) {
-  // VS Drive
-  this->publish_sensor(regs, registers::COMPRESSOR_SPEED_ACTUAL, this->compressor_speed_sensor_);
+  // Compressor speed — source depends on whether VS drive is present.
+  // VS Drive: read directly from register 3001 (actual speed, 0-12 Hz).
+  // Non-VS (Generic): derive from system outputs register 30, per Ruby gem
+  // compressor.rb:36-44 — CC2 → 2, CC → 1, else 0.
+  if (this->has_vs_drive_) {
+    this->publish_sensor(regs, registers::COMPRESSOR_SPEED_ACTUAL, this->compressor_speed_sensor_);
+  } else if (this->compressor_speed_sensor_ != nullptr) {
+    float speed = 0.0f;
+    if (this->system_outputs_ & OUTPUT_CC2) {
+      speed = 2.0f;
+    } else if (this->system_outputs_ & OUTPUT_CC) {
+      speed = 1.0f;
+    }
+    if (sensor_value_changed_(this->compressor_speed_sensor_, speed))
+      this->compressor_speed_sensor_->publish_state(speed);
+  }
   this->publish_sensor_tenths(regs, registers::VS_DISCHARGE_PRESSURE, this->discharge_pressure_sensor_);
   this->publish_sensor_tenths(regs, registers::VS_SUCTION_PRESSURE, this->suction_pressure_sensor_);
   this->publish_sensor(regs, registers::VS_EEV_OPEN, this->eev_open_percentage_sensor_);
@@ -1367,8 +1428,27 @@ void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
   this->publish_sensor(regs, registers::LINE_VOLTAGE_SETTING, this->line_voltage_setting_sensor_);
   this->publish_sensor(regs, registers::COMPRESSOR_ANTI_SHORT_CYCLE, this->anti_short_cycle_sensor_);
   
-  // Blower/ECM
-  this->publish_sensor(regs, registers::ECM_SPEED, this->blower_speed_sensor_);
+  // Blower speed — source depends on blower type.
+  // ECM: read directly from register 344 (actual ECM speed, 0-12).
+  // FiveSpeed: derive from system outputs register 30, per Ruby gem
+  // blower.rb:37-50 — EH1/EH2 → 4, CC2 → 3, CC → 2, BLOWER → 1, else 0.
+  // PSC: no speed register available.
+  if (this->blower_type_ == BlowerType::FIVE_SPEED && this->blower_speed_sensor_ != nullptr) {
+    float speed = 0.0f;
+    if (this->system_outputs_ & (OUTPUT_EH1 | OUTPUT_EH2)) {
+      speed = 4.0f;
+    } else if (this->system_outputs_ & OUTPUT_CC2) {
+      speed = 3.0f;
+    } else if (this->system_outputs_ & OUTPUT_CC) {
+      speed = 2.0f;
+    } else if (this->system_outputs_ & OUTPUT_BLOWER) {
+      speed = 1.0f;
+    }
+    if (sensor_value_changed_(this->blower_speed_sensor_, speed))
+      this->blower_speed_sensor_->publish_state(speed);
+  } else {
+    this->publish_sensor(regs, registers::ECM_SPEED, this->blower_speed_sensor_);
+  }
   this->publish_sensor(regs, registers::BLOWER_ONLY_SPEED, this->blower_only_speed_sensor_);
   this->publish_sensor(regs, registers::LO_COMPRESSOR_ECM_SPEED, this->lo_compressor_speed_sensor_);
   this->publish_sensor(regs, registers::HI_COMPRESSOR_ECM_SPEED, this->hi_compressor_speed_sensor_);
@@ -1403,19 +1483,22 @@ void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
 }
 
 void WaterFurnaceAurora::publish_humidity_control_sensors_(const RegisterMap &regs) {
-  // Humidifier/Dehumidifier running
+  // Humidifier running — OUTPUT_ACCESSORY (0x200) is the accessory relay on register 30.
+  // Per Ruby gem abc_client.rb:201-202, this relay is a humidifier only when the ABC
+  // DIP switch accessory_relay setting is HUMIDIFIER.  We gate on has_humidifier_ so
+  // systems wired for compressor/blower/water valve don't show false humidifier runs.
   publish_binary_if_changed_(this->humidifier_running_sensor_,
-                             (this->system_outputs_ & OUTPUT_ACCESSORY) != 0);
-  // XXX: Dehumidifier detection needs testing during summer cooling season.
-  // Register 362 ("Active Dehumidify") was observed non-zero during heating and idle,
-  // causing false "Drying" action and dehumidifier_running=ON. Gating on the reversing
-  // valve (OUTPUT_RV) is physically correct — VS Drive active dehumidification only
-  // happens during cooling. The AXB dehumidifier relay (0x10) is left ungated as it's
-  // a physical relay output. Verify both signals during actual cooling+dehumidification.
+                             this->has_humidifier_ && (this->system_outputs_ & OUTPUT_ACCESSORY) != 0);
+  // Dehumidifier running — two independent sources:
+  // 1. VS Drive active dehumidification (register 362, gated on reversing valve because
+  //    register 362 can be non-zero during heating/idle — VS dehumidification only
+  //    occurs during cooling when the reversing valve is energized).
+  // 2. AXB dehumidifier relay (0x10 on register 1104) — physical relay output, always
+  //    valid when AXB has dehumidifier installed per axb_extract_accessory_relay2().
   bool cooling_rv = (this->system_outputs_ & OUTPUT_RV) != 0;
   publish_binary_if_changed_(this->dehumidifier_running_sensor_,
                               (this->active_dehumidify_ && cooling_rv)
-                              || ((this->axb_outputs_ & AXB_OUTPUT_DEHUMIDIFIER) != 0));
+                              || (this->has_dehumidifier_ && (this->axb_outputs_ & AXB_OUTPUT_DEHUMIDIFIER) != 0));
   
   // Humidistat
   {

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -167,6 +167,9 @@ void WaterFurnaceAurora::process_response_() {
     case PendingRequest::POLL_REGISTERS:
       this->process_poll_response_(resp);
       break;
+    case PendingRequest::POLL_REGISTERS_MEDIUM:
+      this->process_medium_poll_response_(resp);
+      break;
     case PendingRequest::POLL_FAULT_HISTORY:
       this->process_fault_history_response_(resp);
       break;
@@ -214,6 +217,11 @@ void WaterFurnaceAurora::handle_timeout_() {
     // VS probe failure just means no VS drive — continue setup
     ESP_LOGD(TAG, "VS Drive probe timed out — no VS drive");
     this->finish_setup_();
+  } else if (this->pending_request_ == PendingRequest::POLL_REGISTERS_MEDIUM) {
+    // Medium poll batch timed out — still have the first batch cached.
+    // Publish what we have and continue.
+    ESP_LOGW(TAG, "Medium poll batch timed out — publishing partial data");
+    this->finish_poll_cycle_();
   } else {
     // Normal polling timeout — retry up to read_retries_ before giving up on this cycle.
     this->poll_retry_count_++;
@@ -780,149 +788,149 @@ void WaterFurnaceAurora::build_poll_addresses_() {
   this->addresses_to_read_len_ = 0;
   
   // === TIER 0: Fast registers — every cycle (~5s) ===
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::COMPRESSOR_ANTI_SHORT_CYCLE;
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LAST_FAULT;
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SYSTEM_OUTPUTS;
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SYSTEM_STATUS;
+  this->add_poll_addr_(registers::COMPRESSOR_ANTI_SHORT_CYCLE);
+  this->add_poll_addr_(registers::LAST_FAULT);
+  this->add_poll_addr_(registers::SYSTEM_OUTPUTS);
+  this->add_poll_addr_(registers::SYSTEM_STATUS);
   
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::FP1_TEMP;
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::FP2_TEMP;
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AMBIENT_TEMP;
+  this->add_poll_addr_(registers::FP1_TEMP);
+  this->add_poll_addr_(registers::FP2_TEMP);
+  this->add_poll_addr_(registers::AMBIENT_TEMP);
   
   // Setpoints, mode, and fan config on fast tier — these are writable from HA
   // and must be polled frequently so the write cooldown window (7s) always
   // contains at least one fresh read-back.  Only 4 extra registers per cycle.
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEATING_SETPOINT;
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::COOLING_SETPOINT;
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEATING_MODE_READ;
-  this->addresses_to_read_[this->addresses_to_read_len_++] = registers::FAN_CONFIG;
+  this->add_poll_addr_(registers::HEATING_SETPOINT);
+  this->add_poll_addr_(registers::COOLING_SETPOINT);
+  this->add_poll_addr_(registers::HEATING_MODE_READ);
+  this->add_poll_addr_(registers::FAN_CONFIG);
   
   if (this->awl_axb()) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::ENTERING_AIR_AWL;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LEAVING_AIR;
+    this->add_poll_addr_(registers::ENTERING_AIR_AWL);
+    this->add_poll_addr_(registers::LEAVING_AIR);
   } else {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::ENTERING_AIR;
+    this->add_poll_addr_(registers::ENTERING_AIR);
   }
   if (this->awl_communicating()) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::RELATIVE_HUMIDITY;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::OUTDOOR_TEMP;
+    this->add_poll_addr_(registers::RELATIVE_HUMIDITY);
+    this->add_poll_addr_(registers::OUTDOOR_TEMP);
   }
   if (this->has_axb_) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_OUTPUTS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LEAVING_WATER;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::ENTERING_WATER;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::WATERFLOW;
+    this->add_poll_addr_(registers::AXB_OUTPUTS);
+    this->add_poll_addr_(registers::LEAVING_WATER);
+    this->add_poll_addr_(registers::ENTERING_WATER);
+    this->add_poll_addr_(registers::WATERFLOW);
   }
   
   if (this->refrigeration_monitoring()) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEATING_LIQUID_LINE_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SATURATED_CONDENSER_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SUBCOOL_HEATING;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SUBCOOL_COOLING;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEAT_OF_EXTRACTION;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEAT_OF_EXTRACTION + 1;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEAT_OF_REJECTION;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEAT_OF_REJECTION + 1;
+    this->add_poll_addr_(registers::HEATING_LIQUID_LINE_TEMP);
+    this->add_poll_addr_(registers::SATURATED_CONDENSER_TEMP);
+    this->add_poll_addr_(registers::SUBCOOL_HEATING);
+    this->add_poll_addr_(registers::SUBCOOL_COOLING);
+    this->add_poll_addr_(registers::HEAT_OF_EXTRACTION);
+    this->add_poll_addr_(registers::HEAT_OF_EXTRACTION + 1);
+    this->add_poll_addr_(registers::HEAT_OF_REJECTION);
+    this->add_poll_addr_(registers::HEAT_OF_REJECTION + 1);
   }
   
   if (this->energy_monitoring()) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LINE_VOLTAGE;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::COMPRESSOR_WATTS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::COMPRESSOR_WATTS + 1;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::BLOWER_WATTS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::BLOWER_WATTS + 1;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AUX_WATTS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AUX_WATTS + 1;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::TOTAL_WATTS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::TOTAL_WATTS + 1;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::PUMP_WATTS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::PUMP_WATTS + 1;
+    this->add_poll_addr_(registers::LINE_VOLTAGE);
+    this->add_poll_addr_(registers::COMPRESSOR_WATTS);
+    this->add_poll_addr_(registers::COMPRESSOR_WATTS + 1);
+    this->add_poll_addr_(registers::BLOWER_WATTS);
+    this->add_poll_addr_(registers::BLOWER_WATTS + 1);
+    this->add_poll_addr_(registers::AUX_WATTS);
+    this->add_poll_addr_(registers::AUX_WATTS + 1);
+    this->add_poll_addr_(registers::TOTAL_WATTS);
+    this->add_poll_addr_(registers::TOTAL_WATTS + 1);
+    this->add_poll_addr_(registers::PUMP_WATTS);
+    this->add_poll_addr_(registers::PUMP_WATTS + 1);
   }
   
   // COP requires TOTAL_WATTS + heat registers regardless of energy_monitor_level.
   // When those blocks above didn't already add them, add just what COP needs.
   if (this->cop_sensor_ != nullptr) {
     if (!this->energy_monitoring()) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::TOTAL_WATTS;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::TOTAL_WATTS + 1;
+      this->add_poll_addr_(registers::TOTAL_WATTS);
+      this->add_poll_addr_(registers::TOTAL_WATTS + 1);
     }
     if (!this->refrigeration_monitoring()) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEAT_OF_EXTRACTION;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEAT_OF_EXTRACTION + 1;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEAT_OF_REJECTION;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HEAT_OF_REJECTION + 1;
+      this->add_poll_addr_(registers::HEAT_OF_EXTRACTION);
+      this->add_poll_addr_(registers::HEAT_OF_EXTRACTION + 1);
+      this->add_poll_addr_(registers::HEAT_OF_REJECTION);
+      this->add_poll_addr_(registers::HEAT_OF_REJECTION + 1);
     }
   }
   
   if (this->is_ecm_blower() || this->blower_type_ == BlowerType::FIVE_SPEED) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::ECM_SPEED;
+    this->add_poll_addr_(registers::ECM_SPEED);
   }
   
   if (this->has_vs_drive_) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::ACTIVE_DEHUMIDIFY;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::COMPRESSOR_SPEED_DESIRED;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::COMPRESSOR_SPEED_ACTUAL;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DISCHARGE_PRESSURE;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_SUCTION_PRESSURE;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DISCHARGE_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_AMBIENT_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_INVERTER_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_COMPRESSOR_WATTS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_COMPRESSOR_WATTS + 1;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_FAN_SPEED;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_EEV_OPEN;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_SUCTION_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_SAT_EVAP_DISCHARGE_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_SUPERHEAT_TEMP;
+    this->add_poll_addr_(registers::ACTIVE_DEHUMIDIFY);
+    this->add_poll_addr_(registers::COMPRESSOR_SPEED_DESIRED);
+    this->add_poll_addr_(registers::COMPRESSOR_SPEED_ACTUAL);
+    this->add_poll_addr_(registers::VS_DISCHARGE_PRESSURE);
+    this->add_poll_addr_(registers::VS_SUCTION_PRESSURE);
+    this->add_poll_addr_(registers::VS_DISCHARGE_TEMP);
+    this->add_poll_addr_(registers::VS_AMBIENT_TEMP);
+    this->add_poll_addr_(registers::VS_DRIVE_TEMP);
+    this->add_poll_addr_(registers::VS_INVERTER_TEMP);
+    this->add_poll_addr_(registers::VS_COMPRESSOR_WATTS);
+    this->add_poll_addr_(registers::VS_COMPRESSOR_WATTS + 1);
+    this->add_poll_addr_(registers::VS_FAN_SPEED);
+    this->add_poll_addr_(registers::VS_EEV_OPEN);
+    this->add_poll_addr_(registers::VS_SUCTION_TEMP);
+    this->add_poll_addr_(registers::VS_SAT_EVAP_DISCHARGE_TEMP);
+    this->add_poll_addr_(registers::VS_SUPERHEAT_TEMP);
     // VS Drive additional diagnostics — only poll if at least one sensor is configured
     if (this->vs_entering_water_temperature_sensor_ || this->vs_line_voltage_sensor_ ||
         this->vs_thermo_power_sensor_ || this->vs_supply_voltage_sensor_ ||
         this->vs_udc_voltage_sensor_) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_ENTERING_WATER_TEMP;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_LINE_VOLTAGE;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_THERMO_POWER;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_SUPPLY_VOLTAGE;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_SUPPLY_VOLTAGE + 1;  // uint32 low word
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_UDC_VOLTAGE;
+      this->add_poll_addr_(registers::VS_ENTERING_WATER_TEMP);
+      this->add_poll_addr_(registers::VS_LINE_VOLTAGE);
+      this->add_poll_addr_(registers::VS_THERMO_POWER);
+      this->add_poll_addr_(registers::VS_SUPPLY_VOLTAGE);
+      this->add_poll_addr_(registers::VS_SUPPLY_VOLTAGE + 1);  // uint32 low word
+      this->add_poll_addr_(registers::VS_UDC_VOLTAGE);
     }
   }
   
   if (this->has_axb_ && this->awl_axb()) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_PUMP_SPEED;
+    this->add_poll_addr_(registers::VS_PUMP_SPEED);
     if (this->is_vs_pump()) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_PUMP_MANUAL;
+      this->add_poll_addr_(registers::VS_PUMP_MANUAL);
     }
   }
   
   // AXB current sensors (amps) — only poll if at least one current sensor is configured
   if (this->has_axb_ && (this->blower_amps_sensor_ || this->aux_amps_sensor_ ||
                          this->compressor_1_amps_sensor_ || this->compressor_2_amps_sensor_)) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_BLOWER_AMPS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_AUX_AMPS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_COMPRESSOR1_AMPS;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_COMPRESSOR2_AMPS;
+    this->add_poll_addr_(registers::AXB_BLOWER_AMPS);
+    this->add_poll_addr_(registers::AXB_AUX_AMPS);
+    this->add_poll_addr_(registers::AXB_COMPRESSOR1_AMPS);
+    this->add_poll_addr_(registers::AXB_COMPRESSOR2_AMPS);
   }
 
   // DHW writable registers on fast tier — ensures the 7s write cooldown window
   // always contains at least one fresh read-back (same reason climate setpoints
   // were moved to fast tier).  DHW_TEMP stays on medium tier since it's read-only.
   if (this->has_axb_) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::DHW_ENABLED;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::DHW_SETPOINT;
+    this->add_poll_addr_(registers::DHW_ENABLED);
+    this->add_poll_addr_(registers::DHW_SETPOINT);
   }
   
   if (this->has_iz2_ && this->num_iz2_zones_ > 0) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_OUTDOOR_TEMP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_DEMAND;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_COMPRESSOR_SPEED_DESIRED;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_BLOWER_SPEED_DESIRED;
+    this->add_poll_addr_(registers::IZ2_OUTDOOR_TEMP);
+    this->add_poll_addr_(registers::IZ2_DEMAND);
+    this->add_poll_addr_(registers::IZ2_COMPRESSOR_SPEED_DESIRED);
+    this->add_poll_addr_(registers::IZ2_BLOWER_SPEED_DESIRED);
     
     for (uint8_t zone = 1; zone <= this->num_iz2_zones_; zone++) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_AMBIENT_BASE + ((zone - 1) * 3);
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_CONFIG1_BASE + ((zone - 1) * 3);
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_CONFIG2_BASE + ((zone - 1) * 3);
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_CONFIG3_BASE + ((zone - 1) * 3);
+      this->add_poll_addr_(registers::IZ2_AMBIENT_BASE + ((zone - 1) * 3));
+      this->add_poll_addr_(registers::IZ2_CONFIG1_BASE + ((zone - 1) * 3));
+      this->add_poll_addr_(registers::IZ2_CONFIG2_BASE + ((zone - 1) * 3));
+      this->add_poll_addr_(registers::IZ2_CONFIG3_BASE + ((zone - 1) * 3));
     }
   }
   
@@ -931,56 +939,56 @@ void WaterFurnaceAurora::build_poll_addresses_() {
   // were moved to fast tier to ensure the write cooldown window always contains
   // at least one fresh read-back from the device.
   if (medium_poll) {
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LAST_LOCKOUT_FAULT;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::OUTPUTS_AT_LOCKOUT;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::INPUTS_AT_LOCKOUT;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LINE_VOLTAGE_SETTING;
+    this->add_poll_addr_(registers::LAST_LOCKOUT_FAULT);
+    this->add_poll_addr_(registers::OUTPUTS_AT_LOCKOUT);
+    this->add_poll_addr_(registers::INPUTS_AT_LOCKOUT);
+    this->add_poll_addr_(registers::LINE_VOLTAGE_SETTING);
     
     if (this->has_axb_) {
       // Note: DHW_ENABLED and DHW_SETPOINT moved to fast tier (writable registers
       // need fresh read-back within the 7s cooldown window).
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::DHW_TEMP;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LOOP_PRESSURE;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_INPUTS;
+      this->add_poll_addr_(registers::DHW_TEMP);
+      this->add_poll_addr_(registers::LOOP_PRESSURE);
+      this->add_poll_addr_(registers::AXB_INPUTS);
     }
     
     if (this->is_ecm_blower()) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::BLOWER_ONLY_SPEED;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LO_COMPRESSOR_ECM_SPEED;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HI_COMPRESSOR_ECM_SPEED;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AUX_HEAT_ECM_SPEED;
+      this->add_poll_addr_(registers::BLOWER_ONLY_SPEED);
+      this->add_poll_addr_(registers::LO_COMPRESSOR_ECM_SPEED);
+      this->add_poll_addr_(registers::HI_COMPRESSOR_ECM_SPEED);
+      this->add_poll_addr_(registers::AUX_HEAT_ECM_SPEED);
     }
     
     if (this->has_axb_) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_PUMP_MIN;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_PUMP_MAX;
+      this->add_poll_addr_(registers::VS_PUMP_MIN);
+      this->add_poll_addr_(registers::VS_PUMP_MAX);
     }
     
     if (this->has_vs_drive_) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DERATE;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_SAFE_MODE;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_ALARM1;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_ALARM2;
+      this->add_poll_addr_(registers::VS_DERATE);
+      this->add_poll_addr_(registers::VS_SAFE_MODE);
+      this->add_poll_addr_(registers::VS_ALARM1);
+      this->add_poll_addr_(registers::VS_ALARM2);
     }
     
     if (this->has_iz2_ && this->awl_communicating()) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_HUMIDISTAT_SETTINGS;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_HUMIDISTAT_MODE;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::IZ2_HUMIDISTAT_TARGETS;
+      this->add_poll_addr_(registers::IZ2_HUMIDISTAT_SETTINGS);
+      this->add_poll_addr_(registers::IZ2_HUMIDISTAT_MODE);
+      this->add_poll_addr_(registers::IZ2_HUMIDISTAT_TARGETS);
     } else {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HUMIDISTAT_SETTINGS;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HUMIDISTAT_TARGETS;
+      this->add_poll_addr_(registers::HUMIDISTAT_SETTINGS);
+      this->add_poll_addr_(registers::HUMIDISTAT_TARGETS);
     }
     
     // AXB diagnostic sensors — only poll if at least one is configured
     if (this->has_axb_ && (this->axb_leaving_air_temperature_sensor_ || this->axb_suction_temperature_sensor_ ||
                            this->saturated_evaporator_temperature_sensor_ || this->axb_superheat_sensor_ ||
                            this->vapor_injector_open_sensor_)) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_LEAVING_AIR_TEMP;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_SUCTION_TEMP;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SATURATED_EVAPORATOR_TEMP;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::AXB_SUPERHEAT;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VAPOR_INJECTOR_OPEN;
+      this->add_poll_addr_(registers::AXB_LEAVING_AIR_TEMP);
+      this->add_poll_addr_(registers::AXB_SUCTION_TEMP);
+      this->add_poll_addr_(registers::SATURATED_EVAPORATOR_TEMP);
+      this->add_poll_addr_(registers::AXB_SUPERHEAT);
+      this->add_poll_addr_(registers::VAPOR_INJECTOR_OPEN);
     }
     
     // Configuration/settings registers (gap 11) — only poll if at least one is configured
@@ -988,51 +996,57 @@ void WaterFurnaceAurora::build_poll_addresses_() {
         this->ha_alarm_1_action_sensor_ || this->ha_alarm_2_action_sensor_ || this->energy_phase_type_sensor_ ||
         this->off_time_length_sensor_ || this->power_adj_factor_l_sensor_ || this->power_adj_factor_h_sensor_ ||
         this->smartgrid_trigger_sensor_ || this->ha_alarm_1_trigger_sensor_ || this->ha_alarm_2_trigger_sensor_) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::BRINE_TYPE_REG;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::FLOW_METER_TYPE_REG;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SMARTGRID_TRIGGER;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::SMARTGRID_ACTION_REG;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::OFF_TIME_LENGTH;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HA_ALARM1_TRIGGER;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HA_ALARM1_ACTION;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HA_ALARM2_TRIGGER;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::HA_ALARM2_ACTION;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::ENERGY_PHASE_TYPE_REG;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::POWER_ADJ_FACTOR_L;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::POWER_ADJ_FACTOR_H;
+      this->add_poll_addr_(registers::BRINE_TYPE_REG);
+      this->add_poll_addr_(registers::FLOW_METER_TYPE_REG);
+      this->add_poll_addr_(registers::SMARTGRID_TRIGGER);
+      this->add_poll_addr_(registers::SMARTGRID_ACTION_REG);
+      this->add_poll_addr_(registers::OFF_TIME_LENGTH);
+      this->add_poll_addr_(registers::HA_ALARM1_TRIGGER);
+      this->add_poll_addr_(registers::HA_ALARM1_ACTION);
+      this->add_poll_addr_(registers::HA_ALARM2_TRIGGER);
+      this->add_poll_addr_(registers::HA_ALARM2_ACTION);
+      this->add_poll_addr_(registers::ENERGY_PHASE_TYPE_REG);
+      this->add_poll_addr_(registers::POWER_ADJ_FACTOR_L);
+      this->add_poll_addr_(registers::POWER_ADJ_FACTOR_H);
     }
 
-    // Loop pressure trip and cooling airflow adjustment — poll for number entity read-back
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::LOOP_PRESSURE_TRIP;
-    this->addresses_to_read_[this->addresses_to_read_len_++] = registers::COOLING_AIRFLOW_ADJUSTMENT;
+    // Loop pressure trip and cooling airflow adjustment — only poll when configured.
+    // Number entities read from register_cache_ via get_cached_register*().
+    if (this->loop_pressure_sensor_ != nullptr) {
+      this->add_poll_addr_(registers::LOOP_PRESSURE_TRIP);
+    }
+    // COOLING_AIRFLOW_ADJUSTMENT is polled unconditionally on medium tier since
+    // there's no dedicated sensor pointer — it's read-back-only for the number entity.
+    // The cost is 1 register per medium cycle (~30s), acceptable.
+    this->add_poll_addr_(registers::COOLING_AIRFLOW_ADJUSTMENT);
 
     // Condensate monitoring (gap 13)
     if (this->condensate_sensor_) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::CONDENSATE;
+      this->add_poll_addr_(registers::CONDENSATE);
     }
 
     // VS Drive 3200-range duplicates (gap 14) — only poll if any alt sensor is configured
     if (this->has_vs_drive_ && (this->vs_drive_derate_alt_sensor_ || this->vs_drive_safe_mode_alt_sensor_ ||
                                  this->vs_drive_alarm_alt_sensor_)) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_DERATE_ALT;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_SAFE_MODE_ALT;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_ALARM1_ALT;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_ALARM2_ALT;
+      this->add_poll_addr_(registers::VS_DRIVE_DERATE_ALT);
+      this->add_poll_addr_(registers::VS_DRIVE_SAFE_MODE_ALT);
+      this->add_poll_addr_(registers::VS_DRIVE_ALARM1_ALT);
+      this->add_poll_addr_(registers::VS_DRIVE_ALARM2_ALT);
     }
 
     // VS Drive EEV2 Ctl (gap 15) — only poll if sensor is configured
     if (this->has_vs_drive_ && this->vs_drive_eev2_ctl_sensor_) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::VS_DRIVE_EEV2_CTL;
+      this->add_poll_addr_(registers::VS_DRIVE_EEV2_CTL);
     }
 
     // EEV2 diagnostic sensors — only poll if at least one is configured
     if (this->eev_superheat_sensor_ || this->eev_open_sensor_ || this->eev_suction_temperature_sensor_ ||
         this->eev_saturated_suction_temperature_sensor_ || this->eev2_ctl_sensor_) {
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV2_CTL;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV_SUPERHEAT;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV_OPEN;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV_SUCTION_TEMP;
-      this->addresses_to_read_[this->addresses_to_read_len_++] = registers::EEV_SATURATED_SUCTION_TEMP;
+      this->add_poll_addr_(registers::EEV2_CTL);
+      this->add_poll_addr_(registers::EEV_SUPERHEAT);
+      this->add_poll_addr_(registers::EEV_OPEN);
+      this->add_poll_addr_(registers::EEV_SUCTION_TEMP);
+      this->add_poll_addr_(registers::EEV_SATURATED_SUCTION_TEMP);
     }
   }
 }
@@ -1046,17 +1060,44 @@ void WaterFurnaceAurora::start_poll_cycle_() {
     return;
   }
   
+  // The ABC board limits reads to 100 registers per request.
+  // When the combined fast + medium tier exceeds this limit, we send only
+  // the first batch here; the remainder is sent as a chained second request
+  // after the first response arrives (POLL_REGISTERS_MEDIUM).
+  size_t first_batch = std::min(this->addresses_to_read_len_,
+                                static_cast<size_t>(protocol::MAX_REGISTERS_PER_REQUEST));
+  
   auto frame = protocol::build_read_registers_request(
-      this->address_, this->addresses_to_read_.data(), this->addresses_to_read_len_);
+      this->address_, this->addresses_to_read_.data(), first_batch);
   if (frame.empty()) {
-    ESP_LOGW(TAG, "Failed to build poll request (%d registers — max is %d)",
-             this->addresses_to_read_len_, protocol::MAX_REGISTERS_PER_REQUEST);
+    ESP_LOGW(TAG, "Failed to build poll request (%d registers)", first_batch);
     return;
   }
   
-  // Copy addresses into expected_addresses_ (fixed-size arrays, no heap)
+  ESP_LOGV(TAG, "Poll: %d total addresses, sending batch 1 of %d",
+           this->addresses_to_read_len_, first_batch);
+  
   this->send_request_(frame, PendingRequest::POLL_REGISTERS,
-                      this->addresses_to_read_.data(), this->addresses_to_read_len_);
+                      this->addresses_to_read_.data(), first_batch);
+}
+
+void WaterFurnaceAurora::start_medium_poll_() {
+  // Send the second batch of addresses that didn't fit in the first request.
+  size_t offset = protocol::MAX_REGISTERS_PER_REQUEST;
+  size_t remaining = this->addresses_to_read_len_ - offset;
+  
+  auto frame = protocol::build_read_registers_request(
+      this->address_, this->addresses_to_read_.data() + offset, remaining);
+  if (frame.empty()) {
+    ESP_LOGW(TAG, "Failed to build medium poll request (%d registers)", remaining);
+    this->transition_(State::IDLE);
+    return;
+  }
+  
+  ESP_LOGV(TAG, "Poll: sending batch 2 of %d", remaining);
+  
+  this->send_request_(frame, PendingRequest::POLL_REGISTERS_MEDIUM,
+                      this->addresses_to_read_.data() + offset, remaining);
 }
 
 void WaterFurnaceAurora::process_poll_response_(const protocol::ParsedResponse &resp) {
@@ -1069,7 +1110,28 @@ void WaterFurnaceAurora::process_poll_response_(const protocol::ParsedResponse &
     reg_insert(this->register_cache_, rv.address, rv.value);
   }
   
-  // Publish all sensors from the cache
+  // If there are more addresses to read (medium tier overflow), chain a second
+  // request before publishing sensors. This ensures the register cache is fully
+  // populated before sensor publish runs.
+  if (this->addresses_to_read_len_ > protocol::MAX_REGISTERS_PER_REQUEST) {
+    this->start_medium_poll_();
+    return;
+  }
+  
+  this->finish_poll_cycle_();
+}
+
+void WaterFurnaceAurora::process_medium_poll_response_(const protocol::ParsedResponse &resp) {
+  // Merge second batch into cache
+  for (const auto &rv : resp.registers) {
+    reg_insert(this->register_cache_, rv.address, rv.value);
+  }
+  
+  this->finish_poll_cycle_();
+}
+
+void WaterFurnaceAurora::finish_poll_cycle_() {
+  // Publish all sensors from the fully-populated cache
   this->publish_all_sensors_();
   
   // Check if we need fault history this cycle

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -208,6 +208,15 @@ void WaterFurnaceAurora::handle_timeout_() {
     }
     this->error_backoff_until_ = millis() + ERROR_BACKOFF_MS;
     this->transition_(State::ERROR_BACKOFF);
+  } else if (this->pending_request_ == PendingRequest::POLL_FAULT_HISTORY) {
+    // Fault history read failure — not critical, skip this cycle
+    ESP_LOGD(TAG, "Fault history read timed out");
+    // Chain to dealer info if needed, otherwise go idle
+    if (!this->dealer_info_read_ && this->has_any_dealer_sensor_()) {
+      this->start_dealer_info_read_();
+    } else {
+      this->transition_(State::IDLE);
+    }
   } else if (this->pending_request_ == PendingRequest::POLL_DEALER_INFO) {
     // Dealer info read failure — not critical, skip
     ESP_LOGD(TAG, "Dealer info read timed out");
@@ -1151,7 +1160,10 @@ void WaterFurnaceAurora::finish_poll_cycle_() {
 }
 
 void WaterFurnaceAurora::start_fault_history_read_() {
-  auto frame = protocol::build_read_holding_request(this->address_, registers::FAULT_HISTORY_START, 99);
+  // Ruby gem reads 601..699 via func 0x41 (read contiguous ranges).
+  // The ABC board does not respond to func 0x03 for this register range.
+  auto frame = protocol::build_read_ranges_request(
+      this->address_, {{registers::FAULT_HISTORY_START, 99}});
   
   // Build fault history address list once (static local, persists across calls).
   // Thread-safe: ESPHome main loop is single-threaded; no concurrent access.
@@ -1684,7 +1696,8 @@ void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
   {
     const uint16_t *val = reg_find(regs, subcool_reg);
     if (val) {
-      float fval = to_signed_tenths(*val);
+      // ABC stores subcool with sign; magnitude is what matters for diagnostics
+      float fval = std::abs(to_signed_tenths(*val));
       if (sensor_value_changed_(this->subcool_temperature_sensor_, fval))
         this->subcool_temperature_sensor_->publish_state(fval);
     }
@@ -2211,6 +2224,7 @@ bool WaterFurnaceAurora::set_test_mode(bool enabled) {
 }
 
 bool WaterFurnaceAurora::set_cooling_airflow_adjustment(int16_t value) {
+  if (value < -10 || value > 10) { ESP_LOGW(TAG, "Cooling airflow adjustment out of range: %d", value); return false; }
   // NEGATABLE encoding: negative values stored as 0x10000 + value (two's complement)
   uint16_t raw = static_cast<uint16_t>(value);
   ESP_LOGD(TAG, "Setting cooling airflow adjustment to %d (raw 0x%04X)", value, raw);
@@ -2219,6 +2233,7 @@ bool WaterFurnaceAurora::set_cooling_airflow_adjustment(int16_t value) {
 }
 
 bool WaterFurnaceAurora::set_loop_pressure_trip(float value) {
+  if (value < 0.0f || value > 100.0f) { ESP_LOGW(TAG, "Loop pressure trip out of range: %.1f", value); return false; }
   // Register stores value * 10 (inverse of TO_TENTHS)
   uint16_t raw = static_cast<uint16_t>(value * 10);
   ESP_LOGD(TAG, "Setting loop pressure trip to %.1f psi (raw %d)", value, raw);
@@ -2296,7 +2311,8 @@ void WaterFurnaceAurora::publish_derived_sensors(const RegisterMap &regs) {
     const uint16_t *val_lw = reg_find(regs, registers::LEAVING_WATER);
     const uint16_t *val_ew = reg_find(regs, registers::ENTERING_WATER);
     if (val_lw && val_ew) {
-      this->water_delta_t_sensor_->publish_state(to_signed_tenths(*val_lw) - to_signed_tenths(*val_ew));
+      // Absolute value: in heating EWT > LWT (heat extracted), in cooling LWT > EWT
+      this->water_delta_t_sensor_->publish_state(std::abs(to_signed_tenths(*val_lw) - to_signed_tenths(*val_ew)));
     }
   }
   
@@ -2365,7 +2381,7 @@ void WaterFurnaceAurora::publish_derived_sensors(const RegisterMap &regs) {
         if (cooling && val_ew)
           this->approach_temperature_sensor_->publish_state(sat_cond - to_signed_tenths(*val_ew));
         else if (!cooling && val_lw)
-          this->approach_temperature_sensor_->publish_state(to_signed_tenths(*val_lw) - sat_cond);
+          this->approach_temperature_sensor_->publish_state(sat_cond - to_signed_tenths(*val_lw));
       }
     } else if (sensor_value_changed_(this->approach_temperature_sensor_, NAN)) {
       this->approach_temperature_sensor_->publish_state(NAN);
@@ -2374,15 +2390,17 @@ void WaterFurnaceAurora::publish_derived_sensors(const RegisterMap &regs) {
 }
 
 // ============================================================================
-// Dealer Information (gap 19) — one-shot read via func 0x03
+// Dealer Information (gap 19) — one-shot read via func 0x41
 // ============================================================================
 
 void WaterFurnaceAurora::start_dealer_info_read_() {
   ESP_LOGD(TAG, "Reading dealer information (registers %d-%d)",
            registers::DEALER_INFO_START,
            registers::DEALER_INFO_START + registers::DEALER_INFO_COUNT - 1);
-  auto frame = protocol::build_read_holding_request(
-      this->address_, registers::DEALER_INFO_START, registers::DEALER_INFO_COUNT);
+  // Use func 0x41 (read contiguous ranges) — consistent with Ruby gem's
+  // read_multiple_holding_registers which dispatches Range args to func 0x41.
+  auto frame = protocol::build_read_ranges_request(
+      this->address_, {{registers::DEALER_INFO_START, registers::DEALER_INFO_COUNT}});
 
   // Build expected address list
   static uint16_t dealer_addrs[registers::DEALER_INFO_COUNT];

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -181,6 +181,20 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void set_heat_of_extraction_sensor(sensor::Sensor *sensor) { this->heat_of_extraction_sensor_ = sensor; }
   void set_heat_of_rejection_sensor(sensor::Sensor *sensor) { this->heat_of_rejection_sensor_ = sensor; }
   
+  // AXB diagnostic sensors
+  void set_axb_leaving_air_temperature_sensor(sensor::Sensor *sensor) { this->axb_leaving_air_temperature_sensor_ = sensor; }
+  void set_axb_suction_temperature_sensor(sensor::Sensor *sensor) { this->axb_suction_temperature_sensor_ = sensor; }
+  void set_saturated_evaporator_temperature_sensor(sensor::Sensor *sensor) { this->saturated_evaporator_temperature_sensor_ = sensor; }
+  void set_axb_superheat_sensor(sensor::Sensor *sensor) { this->axb_superheat_sensor_ = sensor; }
+  void set_vapor_injector_open_sensor(sensor::Sensor *sensor) { this->vapor_injector_open_sensor_ = sensor; }
+
+  // EEV2 sensors
+  void set_eev_superheat_sensor(sensor::Sensor *sensor) { this->eev_superheat_sensor_ = sensor; }
+  void set_eev_open_sensor(sensor::Sensor *sensor) { this->eev_open_sensor_ = sensor; }
+  void set_eev_suction_temperature_sensor(sensor::Sensor *sensor) { this->eev_suction_temperature_sensor_ = sensor; }
+  void set_eev_saturated_suction_temperature_sensor(sensor::Sensor *sensor) { this->eev_saturated_suction_temperature_sensor_ = sensor; }
+  void set_eev2_ctl_sensor(text_sensor::TextSensor *sensor) { this->eev2_ctl_sensor_ = sensor; }
+
   // Humidifier sensors
   void set_humidification_target_sensor(sensor::Sensor *sensor) { this->humidification_target_sensor_ = sensor; }
   void set_dehumidification_target_sensor(sensor::Sensor *sensor) { this->dehumidification_target_sensor_ = sensor; }
@@ -202,6 +216,14 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void set_derated_binary_sensor(binary_sensor::BinarySensor *sensor) { this->derated_sensor_ = sensor; }
   void set_safe_mode_binary_sensor(binary_sensor::BinarySensor *sensor) { this->safe_mode_sensor_ = sensor; }
   void set_diverting_valve_binary_sensor(binary_sensor::BinarySensor *sensor) { this->diverting_valve_sensor_ = sensor; }
+
+  // Individual fault history counters (E1-E99)
+  static constexpr size_t FAULT_COUNTER_COUNT = 99;
+  void set_fault_counter_sensor(uint8_t index, sensor::Sensor *sensor) {
+    if (index < FAULT_COUNTER_COUNT) this->fault_counter_sensors_[index] = sensor;
+  }
+  bool has_any_fault_counter_sensor() const { return this->has_any_fault_counter_sensor_; }
+  void set_has_any_fault_counter_sensor() { this->has_any_fault_counter_sensor_ = true; }
 
   // Text sensors
   void set_current_mode_sensor(text_sensor::TextSensor *sensor) { this->current_mode_sensor_ = sensor; }
@@ -259,6 +281,19 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   bool set_humidifier_mode(bool auto_mode);
   bool set_dehumidifier_mode(bool auto_mode);
   
+  // Manual operation / test mode
+  /// Set manual operation mode.
+  /// mode: 0=off, 1=heating, 2=cooling
+  /// compressor_speed: 0-15 (0 = compressor off)
+  /// blower_speed: 0-15, or 255 = match compressor ("with_compressor")
+  /// aux_heat: enable auxiliary electric heat
+  bool set_manual_operation(uint8_t mode, uint8_t compressor_speed,
+                            uint8_t blower_speed, bool aux_heat);
+  /// Turn off manual operation (write 0x7FFF to register 3002).
+  bool set_manual_operation_off();
+  /// Enable/disable test mode (register 45: 1=enable, 0=disable).
+  bool set_test_mode(bool enabled);
+
   // System controls
   bool clear_fault_history();
   
@@ -672,6 +707,19 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   sensor::Sensor *compressor_1_amps_sensor_{nullptr};
   sensor::Sensor *compressor_2_amps_sensor_{nullptr};
 
+  // --- AXB diagnostic sensors ---
+  sensor::Sensor *axb_leaving_air_temperature_sensor_{nullptr};
+  sensor::Sensor *axb_suction_temperature_sensor_{nullptr};
+  sensor::Sensor *saturated_evaporator_temperature_sensor_{nullptr};
+  sensor::Sensor *axb_superheat_sensor_{nullptr};
+  sensor::Sensor *vapor_injector_open_sensor_{nullptr};
+
+  // --- EEV2 sensors ---
+  sensor::Sensor *eev_superheat_sensor_{nullptr};
+  sensor::Sensor *eev_open_sensor_{nullptr};
+  sensor::Sensor *eev_suction_temperature_sensor_{nullptr};
+  sensor::Sensor *eev_saturated_suction_temperature_sensor_{nullptr};
+
   // --- VS Drive sensors ---
   sensor::Sensor *compressor_desired_speed_sensor_{nullptr};
   sensor::Sensor *discharge_temperature_sensor_{nullptr};
@@ -710,6 +758,10 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   // --- Humidity control sensors ---
   sensor::Sensor *humidification_target_sensor_{nullptr};
   sensor::Sensor *dehumidification_target_sensor_{nullptr};
+
+  // --- Fault history counters (E1-E99) ---
+  std::array<sensor::Sensor *, FAULT_COUNTER_COUNT> fault_counter_sensors_{};
+  bool has_any_fault_counter_sensor_{false};
 
   // --- Derived / computed sensors ---
   sensor::Sensor *cop_sensor_{nullptr};
@@ -761,6 +813,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   text_sensor::TextSensor *humidifier_mode_sensor_{nullptr};
   text_sensor::TextSensor *dehumidifier_mode_sensor_{nullptr};
   text_sensor::TextSensor *pump_type_sensor_{nullptr};
+  text_sensor::TextSensor *eev2_ctl_sensor_{nullptr};
   
   // --- Lockout diagnostic sensors ---
   sensor::Sensor *lockout_fault_code_sensor_{nullptr};
@@ -792,6 +845,8 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   uint16_t cached_axb_inputs_raw_{0xFFFF};
   std::string cached_humidifier_mode_;
   std::string cached_dehumidifier_mode_;
+  std::string cached_eev2_ctl_;
+  uint16_t cached_eev2_ctl_raw_{0xFFFF};
   std::string cached_lockout_fault_description_;
   std::string cached_outputs_at_lockout_;
   uint16_t cached_outputs_at_lockout_raw_{0xFFFF};

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -295,6 +295,9 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   bool get_humidifier_auto() const { return this->humidifier_auto_; }
   bool get_dehumidifier_auto() const { return this->dehumidifier_auto_; }
   bool awl_communicating() const { return this->awl_thermostat() || this->awl_iz2(); }
+  bool has_humidifier() const { return this->has_humidifier_; }
+  bool has_dehumidifier() const { return this->has_dehumidifier_; }
+  const DipSwitchSettings &get_dip_switches() const { return this->dip_switches_; }
   
   /// Look up a raw register value from the cache. Returns NAN if not found.
   /// Used by AuroraNumber entities to get current read-back values.
@@ -610,6 +613,9 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   BlowerType blower_type_{BlowerType::PSC};
   PumpType pump_type_{PumpType::OTHER};
   uint8_t energy_monitor_level_{0};
+  DipSwitchSettings dip_switches_;    // Parsed DIP switch settings (register 33)
+  bool has_humidifier_{false};         // DIP accessory_relay == HUMIDIFIER
+  bool has_dehumidifier_{false};       // AXB present && accessory_relay2 == DEHUMIDIFIER
   
   // IZ2 Zone data
   IZ2ZoneData iz2_zones_[MAX_IZ2_ZONES];

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -364,6 +364,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   uint16_t get_axb_outputs() const { return this->axb_outputs_; }
   bool is_locked_out() const { return this->locked_out_; }
   bool is_setup_complete() const { return this->setup_complete_; }
+  bool needs_redetect() const { return this->needs_redetect_; }
   bool is_active_dehumidify() const { return this->active_dehumidify_; }
   float get_relative_humidity() const { return this->relative_humidity_; }
   bool get_humidifier_auto() const { return this->humidifier_auto_; }
@@ -418,6 +419,8 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   }
 
   // IZ2 Zone getters
+  bool get_axb_status() const { return this->has_axb_; }
+  bool get_vs_drive_status() const { return this->has_vs_drive_; }
   bool has_iz2() const { return this->has_iz2_; }
   uint8_t get_num_iz2_zones() const { return this->num_iz2_zones_; }
   const IZ2ZoneData& get_zone_data(uint8_t zone_number) const;
@@ -628,6 +631,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   State state_{State::SETUP_READ_ID};
   PendingRequest pending_request_{PendingRequest::NONE};
   bool setup_complete_{false};
+  bool needs_redetect_{false};
   uint8_t setup_retry_count_{0};
   uint8_t poll_retry_count_{0};     // Retry counter for normal poll-cycle timeouts
   static constexpr uint8_t MAX_SETUP_RETRIES = 5;

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -44,7 +44,8 @@ enum class PendingRequest : uint8_t {
   SETUP_ID,          // func 0x03 read for model/serial
   SETUP_DETECT,      // func 0x42 read for hardware detection
   SETUP_VS_PROBE,    // func 0x42 read for VS drive probing
-  POLL_REGISTERS,    // func 0x42 read for normal polling
+  POLL_REGISTERS,    // func 0x42 read for normal polling (first batch)
+  POLL_REGISTERS_MEDIUM, // func 0x42 read for medium-tier overflow (second batch)
   POLL_FAULT_HISTORY,// func 0x03 read for fault history
   POLL_DEALER_INFO,  // func 0x03 read for dealer information
   WRITE_SINGLE,      // func 0x06 write
@@ -454,8 +455,11 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   
   // --- Polling ---
   void start_poll_cycle_();
+  void start_medium_poll_();
   void start_fault_history_read_();
   void process_poll_response_(const protocol::ParsedResponse &resp);
+  void process_medium_poll_response_(const protocol::ParsedResponse &resp);
+  void finish_poll_cycle_();
   void process_fault_history_response_(const protocol::ParsedResponse &resp);
   void start_dealer_info_read_();
   void process_dealer_info_response_(const protocol::ParsedResponse &resp);
@@ -476,6 +480,14 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void publish_config_sensors_(const RegisterMap &regs);
   void publish_humidity_control_sensors_(const RegisterMap &regs);
   void publish_iz2_zone_sensors_(const RegisterMap &regs);
+  
+  /// Bounds-checked address insertion for poll address arrays.
+  /// Silently stops adding if the buffer is full (logged once in start_poll_cycle_).
+  void add_poll_addr_(uint16_t addr) {
+    if (this->addresses_to_read_len_ < MAX_POLL_ADDRESSES) {
+      this->addresses_to_read_[this->addresses_to_read_len_++] = addr;
+    }
+  }
   
   // --- Write handling ---
   void process_pending_writes_();
@@ -672,7 +684,10 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   RegisterMap register_cache_;
   
   // Pre-allocated array for register addresses (built each poll cycle).
-  std::array<uint16_t, protocol::MAX_REGISTERS_PER_REQUEST> addresses_to_read_;
+  // Sized to 2× MAX_REGISTERS_PER_REQUEST to accommodate fast + medium tier
+  // addresses before splitting into separate ABC requests (100-register limit).
+  static constexpr size_t MAX_POLL_ADDRESSES = 200;
+  std::array<uint16_t, MAX_POLL_ADDRESSES> addresses_to_read_;
   size_t addresses_to_read_len_{0};
   
   // --- Heat pump state ---

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -46,6 +46,7 @@ enum class PendingRequest : uint8_t {
   SETUP_VS_PROBE,    // func 0x42 read for VS drive probing
   POLL_REGISTERS,    // func 0x42 read for normal polling
   POLL_FAULT_HISTORY,// func 0x03 read for fault history
+  POLL_DEALER_INFO,  // func 0x03 read for dealer information
   WRITE_SINGLE,      // func 0x06 write
   // Note: func 0x43 (batch write) is supported by the protocol layer but NOT used
   // by the hub. The Aurora firmware rejects 0x43 with error 0x02. All writes use
@@ -195,6 +196,39 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void set_eev_saturated_suction_temperature_sensor(sensor::Sensor *sensor) { this->eev_saturated_suction_temperature_sensor_ = sensor; }
   void set_eev2_ctl_sensor(text_sensor::TextSensor *sensor) { this->eev2_ctl_sensor_ = sensor; }
 
+  // Configuration/settings sensors (gap 11)
+  void set_brine_type_sensor(text_sensor::TextSensor *sensor) { this->brine_type_sensor_ = sensor; }
+  void set_flow_meter_type_sensor(text_sensor::TextSensor *sensor) { this->flow_meter_type_sensor_ = sensor; }
+  void set_smartgrid_action_sensor(text_sensor::TextSensor *sensor) { this->smartgrid_action_sensor_ = sensor; }
+  void set_ha_alarm_1_action_sensor(text_sensor::TextSensor *sensor) { this->ha_alarm_1_action_sensor_ = sensor; }
+  void set_ha_alarm_2_action_sensor(text_sensor::TextSensor *sensor) { this->ha_alarm_2_action_sensor_ = sensor; }
+  void set_energy_phase_type_sensor(text_sensor::TextSensor *sensor) { this->energy_phase_type_sensor_ = sensor; }
+  void set_off_time_length_sensor(sensor::Sensor *sensor) { this->off_time_length_sensor_ = sensor; }
+  void set_power_adj_factor_l_sensor(sensor::Sensor *sensor) { this->power_adj_factor_l_sensor_ = sensor; }
+  void set_power_adj_factor_h_sensor(sensor::Sensor *sensor) { this->power_adj_factor_h_sensor_ = sensor; }
+  void set_smartgrid_trigger_binary_sensor(binary_sensor::BinarySensor *sensor) { this->smartgrid_trigger_sensor_ = sensor; }
+  void set_ha_alarm_1_trigger_binary_sensor(binary_sensor::BinarySensor *sensor) { this->ha_alarm_1_trigger_sensor_ = sensor; }
+  void set_ha_alarm_2_trigger_binary_sensor(binary_sensor::BinarySensor *sensor) { this->ha_alarm_2_trigger_sensor_ = sensor; }
+
+  // Condensate sensor (gap 13)
+  void set_condensate_sensor(sensor::Sensor *sensor) { this->condensate_sensor_ = sensor; }
+
+  // VS Drive 3200-range duplicates (gap 14)
+  void set_vs_drive_derate_alt_sensor(text_sensor::TextSensor *sensor) { this->vs_drive_derate_alt_sensor_ = sensor; }
+  void set_vs_drive_safe_mode_alt_sensor(text_sensor::TextSensor *sensor) { this->vs_drive_safe_mode_alt_sensor_ = sensor; }
+  void set_vs_drive_alarm_alt_sensor(text_sensor::TextSensor *sensor) { this->vs_drive_alarm_alt_sensor_ = sensor; }
+
+  // VS Drive EEV2 Ctl (gap 15)
+  void set_vs_drive_eev2_ctl_sensor(text_sensor::TextSensor *sensor) { this->vs_drive_eev2_ctl_sensor_ = sensor; }
+
+  // Dealer information (gap 19)
+  void set_dealer_name_sensor(text_sensor::TextSensor *sensor) { this->dealer_name_sensor_ = sensor; }
+  void set_dealer_phone_sensor(text_sensor::TextSensor *sensor) { this->dealer_phone_sensor_ = sensor; }
+  void set_dealer_address_1_sensor(text_sensor::TextSensor *sensor) { this->dealer_address_1_sensor_ = sensor; }
+  void set_dealer_address_2_sensor(text_sensor::TextSensor *sensor) { this->dealer_address_2_sensor_ = sensor; }
+  void set_dealer_email_sensor(text_sensor::TextSensor *sensor) { this->dealer_email_sensor_ = sensor; }
+  void set_dealer_website_sensor(text_sensor::TextSensor *sensor) { this->dealer_website_sensor_ = sensor; }
+
   // Humidifier sensors
   void set_humidification_target_sensor(sensor::Sensor *sensor) { this->humidification_target_sensor_ = sensor; }
   void set_dehumidification_target_sensor(sensor::Sensor *sensor) { this->dehumidification_target_sensor_ = sensor; }
@@ -294,6 +328,10 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   /// Enable/disable test mode (register 45: 1=enable, 0=disable).
   bool set_test_mode(bool enabled);
 
+  // Configuration controls (gap 11, 12)
+  bool set_cooling_airflow_adjustment(int16_t value);
+  bool set_loop_pressure_trip(float value);
+
   // System controls
   bool clear_fault_history();
   
@@ -345,6 +383,18 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   float get_cached_register_tenths(uint16_t addr) const {
     const uint16_t *val = reg_find(this->register_cache_, addr);
     return val ? to_tenths(*val) : NAN;
+  }
+
+  /// Look up a register and return it as a signed integer (NEGATABLE). Returns NAN if not found.
+  float get_cached_register_signed(uint16_t addr) const {
+    const uint16_t *val = reg_find(this->register_cache_, addr);
+    return val ? static_cast<float>(static_cast<int16_t>(*val)) : NAN;
+  }
+
+  /// Look up a register value and return it divided by 100. Returns NAN if not found.
+  float get_cached_register_hundredths(uint16_t addr) const {
+    const uint16_t *val = reg_find(this->register_cache_, addr);
+    return val ? to_hundredths(*val) : NAN;
   }
   
   // Observer pattern: sub-entities register a callback to be notified when data updates.
@@ -407,6 +457,14 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void start_fault_history_read_();
   void process_poll_response_(const protocol::ParsedResponse &resp);
   void process_fault_history_response_(const protocol::ParsedResponse &resp);
+  void start_dealer_info_read_();
+  void process_dealer_info_response_(const protocol::ParsedResponse &resp);
+  /// Returns true if any dealer info text sensor is configured.
+  bool has_any_dealer_sensor_() const {
+    return this->dealer_name_sensor_ || this->dealer_phone_sensor_ ||
+           this->dealer_address_1_sensor_ || this->dealer_address_2_sensor_ ||
+           this->dealer_email_sensor_ || this->dealer_website_sensor_;
+  }
   void publish_all_sensors_();
   void publish_fault_sensors_(const RegisterMap &regs);
   void publish_system_status_sensors_(const RegisterMap &regs);
@@ -415,6 +473,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void publish_power_loop_sensors_(const RegisterMap &regs);
   void publish_vs_drive_sensors_(const RegisterMap &regs);
   void publish_equipment_sensors_(const RegisterMap &regs);
+  void publish_config_sensors_(const RegisterMap &regs);
   void publish_humidity_control_sensors_(const RegisterMap &regs);
   void publish_iz2_zone_sensors_(const RegisterMap &regs);
   
@@ -763,6 +822,14 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   std::array<sensor::Sensor *, FAULT_COUNTER_COUNT> fault_counter_sensors_{};
   bool has_any_fault_counter_sensor_{false};
 
+  // --- Configuration/settings sensors (gap 11) ---
+  sensor::Sensor *off_time_length_sensor_{nullptr};
+  sensor::Sensor *power_adj_factor_l_sensor_{nullptr};
+  sensor::Sensor *power_adj_factor_h_sensor_{nullptr};
+
+  // --- Condensate sensor (gap 13) ---
+  sensor::Sensor *condensate_sensor_{nullptr};
+
   // --- Derived / computed sensors ---
   sensor::Sensor *cop_sensor_{nullptr};
   sensor::Sensor *water_delta_t_sensor_{nullptr};
@@ -796,6 +863,11 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   binary_sensor::BinarySensor *humidifier_running_sensor_{nullptr};
   binary_sensor::BinarySensor *dehumidifier_running_sensor_{nullptr};
 
+  // --- Configuration triggers (gap 11) ---
+  binary_sensor::BinarySensor *smartgrid_trigger_sensor_{nullptr};
+  binary_sensor::BinarySensor *ha_alarm_1_trigger_sensor_{nullptr};
+  binary_sensor::BinarySensor *ha_alarm_2_trigger_sensor_{nullptr};
+
   // =========================================================================
   // Text sensors
   // =========================================================================
@@ -814,7 +886,31 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   text_sensor::TextSensor *dehumidifier_mode_sensor_{nullptr};
   text_sensor::TextSensor *pump_type_sensor_{nullptr};
   text_sensor::TextSensor *eev2_ctl_sensor_{nullptr};
-  
+
+  // --- Configuration text sensors (gap 11) ---
+  text_sensor::TextSensor *brine_type_sensor_{nullptr};
+  text_sensor::TextSensor *flow_meter_type_sensor_{nullptr};
+  text_sensor::TextSensor *smartgrid_action_sensor_{nullptr};
+  text_sensor::TextSensor *ha_alarm_1_action_sensor_{nullptr};
+  text_sensor::TextSensor *ha_alarm_2_action_sensor_{nullptr};
+  text_sensor::TextSensor *energy_phase_type_sensor_{nullptr};
+
+  // --- VS Drive 3200-range duplicates (gap 14) ---
+  text_sensor::TextSensor *vs_drive_derate_alt_sensor_{nullptr};
+  text_sensor::TextSensor *vs_drive_safe_mode_alt_sensor_{nullptr};
+  text_sensor::TextSensor *vs_drive_alarm_alt_sensor_{nullptr};
+
+  // --- VS Drive EEV2 Ctl (gap 15) ---
+  text_sensor::TextSensor *vs_drive_eev2_ctl_sensor_{nullptr};
+
+  // --- Dealer information (gap 19) ---
+  text_sensor::TextSensor *dealer_name_sensor_{nullptr};
+  text_sensor::TextSensor *dealer_phone_sensor_{nullptr};
+  text_sensor::TextSensor *dealer_address_1_sensor_{nullptr};
+  text_sensor::TextSensor *dealer_address_2_sensor_{nullptr};
+  text_sensor::TextSensor *dealer_email_sensor_{nullptr};
+  text_sensor::TextSensor *dealer_website_sensor_{nullptr};
+
   // --- Lockout diagnostic sensors ---
   sensor::Sensor *lockout_fault_code_sensor_{nullptr};
   text_sensor::TextSensor *lockout_fault_description_sensor_{nullptr};
@@ -847,6 +943,32 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   std::string cached_dehumidifier_mode_;
   std::string cached_eev2_ctl_;
   uint16_t cached_eev2_ctl_raw_{0xFFFF};
+  // Config register text sensor caches (gap 11)
+  std::string cached_brine_type_;
+  std::string cached_flow_meter_type_;
+  std::string cached_smartgrid_action_;
+  std::string cached_ha_alarm_1_action_;
+  std::string cached_ha_alarm_2_action_;
+  std::string cached_energy_phase_type_;
+  // VS Drive alt text sensor caches (gap 14)
+  std::string cached_vs_drive_derate_alt_;
+  uint16_t cached_vs_drive_derate_alt_raw_{0xFFFF};
+  std::string cached_vs_drive_safe_mode_alt_;
+  uint16_t cached_vs_drive_safe_mode_alt_raw_{0xFFFF};
+  std::string cached_vs_drive_alarm_alt_;
+  uint16_t cached_vs_drive_alarm1_alt_raw_{0xFFFF};
+  uint16_t cached_vs_drive_alarm2_alt_raw_{0xFFFF};
+  // VS Drive EEV2 Ctl cache (gap 15)
+  std::string cached_vs_drive_eev2_ctl_;
+  uint16_t cached_vs_drive_eev2_ctl_raw_{0xFFFF};
+  // Dealer info caches (gap 19)
+  std::string cached_dealer_name_;
+  std::string cached_dealer_phone_;
+  std::string cached_dealer_address_1_;
+  std::string cached_dealer_address_2_;
+  std::string cached_dealer_email_;
+  std::string cached_dealer_website_;
+  bool dealer_info_read_{false};
   std::string cached_lockout_fault_description_;
   std::string cached_outputs_at_lockout_;
   uint16_t cached_outputs_at_lockout_raw_{0xFFFF};

--- a/local_dev.yaml
+++ b/local_dev.yaml
@@ -161,6 +161,7 @@ number:
     # dhw_setpoint:
     #   name: "DHW Setpoint"
     # Indoor Blower/ECM speed settings (1-12)
+    # NOTE: Requires ECM blower (blower type 1 or 2). Shows "Unknown" on PSC/5-speed blowers.
     blower_only_speed:
       name: "Indoor Blower Only Speed"
     lo_compressor_speed:
@@ -170,6 +171,7 @@ number:
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed"
     # Loop Pump speed settings (1-100%)
+    # NOTE: Requires variable speed (VS) pump. Shows "Unknown" on fixed-speed pumps.
     pump_min_speed:
       name: "Loop Pump Minimum Speed"
     pump_max_speed:
@@ -197,13 +199,13 @@ sensor:
     aurora_id: aurora
     
     # Air temperatures
-    entering_air_temperature:
+    entering_air_temperature:  # reads register 740 (AWL AXB) or 567 (non-AWL); suppresses 0 values
       name: "Return Air Temperature"
-    leaving_air_temperature:  # requires AWL AXB (AXB firmware >= v2.0)
+    leaving_air_temperature:  # requires AWL AXB (AXB firmware >= v2.0); shows "Unknown" otherwise
       name: "Supply Air Temperature"
     ambient_temperature:
       name: "Ambient Temperature"
-    outdoor_temperature:
+    outdoor_temperature:  # requires AWL communicating thermostat; suppresses 0 values
       name: "Outdoor Temperature"
     
     # Water/loop temperatures
@@ -234,15 +236,15 @@ sensor:
     compressor_desired_speed:
       name: "Compressor Desired Speed"
     
-    # Pressures
+    # Pressures (requires VS drive for discharge/suction; AXB for loop pressure)
     discharge_pressure:
       name: "Discharge Pressure"
     suction_pressure:
       name: "Suction Pressure"
-    loop_pressure:
+    loop_pressure:  # requires AXB board with pressure sensor hardware
       name: "Loop Pressure"
     
-    # Refrigeration
+    # Refrigeration (requires VS drive; requires refrigeration monitoring for liquid line/subcool)
     eev_open_percentage:
       name: "EEV Open Percentage"
     superheat_temperature:
@@ -262,7 +264,7 @@ sensor:
     fp2_temperature:
       name: "FP2 Temperature"
     
-    # VS Drive temperatures
+    # VS Drive temperatures (requires VS drive; shows "Unknown" on non-VS systems)
     vs_drive_temperature:
       name: "VS Drive Temperature"
     vs_inverter_temperature:
@@ -272,7 +274,7 @@ sensor:
     saturated_evaporator_discharge_temperature:
       name: "Saturated Evaporator Discharge Temperature"
     
-    # VS Drive additional
+    # VS Drive additional (requires VS drive)
     vs_fan_speed:
       name: "VS Fan Speed"
     vs_compressor_watts:
@@ -282,7 +284,7 @@ sensor:
     aux_heat_stage:
       name: "Aux Electric Heat Stage"
     
-    # Energy / Power
+    # Energy / Power (requires energy monitoring level >= 2)
     line_voltage:
       name: "Line Voltage"
     total_watts:
@@ -305,6 +307,8 @@ sensor:
       name: "Loop Flow Rate"
     
     # Indoor Blower/ECM speeds
+    # NOTE: blower_speed works for all blower types (ECM reads register, others derive from outputs).
+    # The _setting sensors require ECM blower (type 1 or 2); show "Unknown" on PSC/5-speed.
     blower_speed:
       name: "Indoor Blower Speed"
     blower_only_speed:
@@ -316,7 +320,7 @@ sensor:
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed Setting"
     
-    # Loop Pump speeds
+    # Loop Pump speeds (requires variable speed pump; show "Unknown" on fixed-speed pumps)
     pump_speed:
       name: "Loop Pump Speed"
     pump_min_speed:
@@ -348,12 +352,12 @@ sensor:
     # iz2_unit_demand:
     #   name: "IZ2 Unit Demand"
     
-    # Derived sensors (computed on-device)
-    cop:
+    # Derived sensors (computed on-device; require underlying registers to be available)
+    cop:  # requires energy monitoring + compressor running; shows 0 when idle
       name: "Coefficient of Performance"
-    water_delta_t:
+    water_delta_t:  # requires AXB (leaving/entering water temps)
       name: "Water Delta-T"
-    approach_temperature:
+    approach_temperature:  # requires refrigeration monitoring + compressor running; "Unknown" when idle
       name: "Approach Temperature"
 
   # WiFi signal strength
@@ -437,7 +441,7 @@ text_sensor:
     serial_number:
       name: "Serial Number"
     
-    # VS Drive status
+    # VS Drive status (requires VS drive; show "Unknown" on non-VS systems)
     vs_derate:
       name: "VS Drive Derate"
     vs_safe_mode:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,7 @@
 CXX ?= g++
 
 # Base flags with debug info for meaningful stack traces
-BASE_FLAGS = -std=gnu++20 -Wall -Wextra -Wpedantic -g -O0
+BASE_FLAGS = -std=gnu++20 -Wall -Wextra -Wpedantic -g -O2
 
 # Enable sanitizers when available (disable with SANITIZE=0)
 SANITIZE ?= 1

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -866,7 +866,7 @@ TEST_CASE("Approach temperature requires compressor running", "[hub][sensors][de
   hub.loop();
   REQUIRE(hub.is_setup_complete());
 
-  auto run_poll = [&](uint16_t outputs, uint16_t sat_cond, uint16_t lwt,
+  auto run_poll = [&](uint16_t outputs, uint16_t sat_cond, uint16_t leaving_air,
                       uint16_t ewt, uint32_t time_ms) {
     set_millis(time_ms);
     hub.update();
@@ -881,7 +881,7 @@ TEST_CASE("Approach temperature requires compressor running", "[hub][sensors][de
       uint16_t val = 0;
       if (addr == registers::SYSTEM_OUTPUTS) val = outputs;
       if (addr == registers::SATURATED_CONDENSER_TEMP) val = sat_cond;
-      if (addr == registers::LEAVING_WATER) val = lwt;
+      if (addr == registers::LEAVING_AIR) val = leaving_air;
       if (addr == registers::ENTERING_WATER) val = ewt;
       resp_vals.emplace_back(addr, val);
     }
@@ -892,36 +892,37 @@ TEST_CASE("Approach temperature requires compressor running", "[hub][sensors][de
 
   SECTION("compressor off → publishes NAN") {
     // No CC/CC2 in outputs = compressor off
-    // sat_cond=500 (50.0), lwt=520 (52.0), ewt=480 (48.0)
-    run_poll(0x0000, 500, 520, 480, 200);
+    // sat_cond=500 (50.0), leaving_air=720 (72.0), ewt=480 (48.0)
+    run_poll(0x0000, 500, 720, 480, 200);
     REQUIRE(approach.has_state_);
     REQUIRE(std::isnan(approach.state));
   }
 
-  SECTION("compressor on heating → publishes SatCond - LWT") {
+  SECTION("compressor on heating → publishes SatCond - LeavingAir") {
     // CC bit (0x01) set, no RV = heating mode
-    // In heating, condenser heats water: sat_cond > LWT.
-    // sat_cond=550 (55.0°F), lwt=520 (52.0°F) → approach = 55.0 - 52.0 = 3.0
-    run_poll(OUTPUT_CC, 550, 520, 480, 200);
+    // In heating, condenser is indoor air coil: sat_cond > leaving_air.
+    // sat_cond=1050 (105.0°F), leaving_air=1020 (102.0°F) → approach = 105.0 - 102.0 = 3.0
+    run_poll(OUTPUT_CC, 1050, 1020, 480, 200);
     REQUIRE(approach.has_state_);
     REQUIRE(approach.state == Catch::Approx(3.0f));
   }
 
   SECTION("compressor on cooling → publishes SatCond - EWT") {
     // CC bit (0x01) + RV bit (0x04) = cooling mode
-    // sat_cond=500 (50.0°F), ewt=480 (48.0°F) → approach = 50.0 - 48.0 = 2.0
-    run_poll(OUTPUT_CC | OUTPUT_RV, 500, 530, 480, 200);
+    // sat_cond=500 (50.0°F), leaving_air=550 (55.0°F), ewt=480 (48.0°F)
+    // approach = 50.0 - 48.0 = 2.0 (leaving_air unused in cooling)
+    run_poll(OUTPUT_CC | OUTPUT_RV, 500, 550, 480, 200);
     REQUIRE(approach.has_state_);
     REQUIRE(approach.state == Catch::Approx(2.0f));
   }
 
   SECTION("transition from running to idle clears to NAN") {
-    // First: compressor running → valid approach
-    run_poll(OUTPUT_CC, 500, 530, 480, 200);
+    // First: compressor running in cooling → valid approach
+    run_poll(OUTPUT_CC | OUTPUT_RV, 500, 550, 480, 200);
     REQUIRE_FALSE(std::isnan(approach.state));
 
     // Then: compressor off → NAN
-    run_poll(0x0000, 500, 530, 480, 300);
+    run_poll(0x0000, 500, 550, 480, 300);
     REQUIRE(std::isnan(approach.state));
   }
 }

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -898,10 +898,11 @@ TEST_CASE("Approach temperature requires compressor running", "[hub][sensors][de
     REQUIRE(std::isnan(approach.state));
   }
 
-  SECTION("compressor on heating → publishes LWT - SatCond") {
+  SECTION("compressor on heating → publishes SatCond - LWT") {
     // CC bit (0x01) set, no RV = heating mode
-    // sat_cond=500 (50.0°F), lwt=530 (53.0°F) → approach = 53.0 - 50.0 = 3.0
-    run_poll(OUTPUT_CC, 500, 530, 480, 200);
+    // In heating, condenser heats water: sat_cond > LWT.
+    // sat_cond=550 (55.0°F), lwt=520 (52.0°F) → approach = 55.0 - 52.0 = 3.0
+    run_poll(OUTPUT_CC, 550, 520, 480, 200);
     REQUIRE(approach.has_state_);
     REQUIRE(approach.state == Catch::Approx(3.0f));
   }

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -207,6 +207,90 @@ TEST_CASE("IZ2 zone validation", "[hub][iz2]") {
 }
 
 // ============================================================================
+// Setup Failure & Re-Detection (Issue 17)
+// ============================================================================
+
+TEST_CASE("Setup failure and re-detection", "[hub][state][redetect]") {
+  WaterFurnaceAurora hub;
+  
+  // Create a minimal sensor to verify normal operation restoration
+  sensor::Sensor entering_water;
+  hub.set_entering_water_temperature_sensor(&entering_water);
+  
+  set_millis(0);
+  hub.setup();
+
+  SECTION("setup timeout after MAX_SETUP_RETRIES sets needs_redetect") {
+    // Loop through 5 timeout cycles
+    for (int i = 0; i < 5; i++) {
+      hub.loop();                  // sends ID request → TX_PENDING
+      hub.mock_get_transmitted();  // drain tx
+      complete_tx(hub, millis());  // WAITING_RESPONSE
+      
+      // Advance past timeout
+      set_millis(millis() + 2100);
+      hub.loop();  // handle_timeout_() -> increments retry count -> ERROR_BACKOFF
+      
+      if (i < 4) {
+        // Advance past backoff to start next retry
+        set_millis(millis() + 5000);
+        hub.loop();  // exits ERROR_BACKOFF -> SETUP_READ_ID
+      }
+    }
+    
+    // On the 5th timeout (now), finish_setup_() is called with defaults
+    REQUIRE(hub.is_setup_complete());
+    REQUIRE(hub.needs_redetect());
+    REQUIRE_FALSE(hub.get_axb_status()); // Default is false
+  }
+
+  SECTION("first successful poll after failed setup triggers re-detection") {
+    // 1. Force state to failed setup
+    // We can't easily drive the loop 5 times in a sub-section without copy-paste,
+    // so we'll simulate the end state by using the public API where possible,
+    // but here we really need to just drive it.
+    for (int i = 0; i < 5; i++) {
+      hub.loop(); hub.mock_get_transmitted(); complete_tx(hub, millis());
+      set_millis(millis() + 2100); hub.loop();
+      if (i < 4) { set_millis(millis() + 5000); hub.loop(); }
+    }
+    REQUIRE(hub.needs_redetect());
+
+    // 2. Trigger a poll cycle
+    set_millis(millis() + 100);
+    hub.update(); // builds minimal fast-tier address list
+    auto tx = hub.mock_get_transmitted();
+    REQUIRE(tx.size() > 0);
+    complete_tx(hub, millis());
+
+    // 3. Feed a valid 0x42 response
+    // Response just needs to correspond to the requested registers.
+    // Since detection failed, it's the minimal set.
+    size_t num_regs = (tx.size() - 4) / 2;
+    std::vector<std::pair<uint16_t, uint16_t>> resp_vals;
+    for (size_t i = 0; i < num_regs; i++) {
+      uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+      resp_vals.emplace_back(addr, 0); // Value doesn't matter much for triggering re-detect
+    }
+    hub.mock_receive(make_response_42(resp_vals));
+
+    // 4. Process response -> trigger re-detect
+    set_millis(millis() + 50);
+    hub.loop(); 
+    
+    // Should have transitioned back to setup
+    REQUIRE_FALSE(hub.is_setup_complete());
+    REQUIRE_FALSE(hub.needs_redetect()); // Flag cleared
+    
+    // Next loop should send ID request
+    hub.loop();
+    tx = hub.mock_get_transmitted();
+    REQUIRE(tx.size() > 0);
+    REQUIRE(tx[1] == 0x03); // func 0x03 ID request
+  }
+}
+
+// ============================================================================
 // Setup Callbacks
 // ============================================================================
 

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -635,6 +635,297 @@ TEST_CASE("Leaving air temperature on non-AWL systems", "[hub][sensors]") {
 }
 
 // ============================================================================
+// Pressure Switch Polarity (field validation fix)
+// ============================================================================
+
+TEST_CASE("Pressure switch polarity", "[hub][sensors][binary]") {
+  WaterFurnaceAurora hub;
+  binary_sensor::BinarySensor lps;
+  binary_sensor::BinarySensor hps;
+  hub.set_low_pressure_switch_binary_sensor(&lps);
+  hub.set_high_pressure_switch_binary_sensor(&hps);
+
+  set_millis(0);
+  drive_setup(hub);
+  REQUIRE(hub.is_setup_complete());
+
+  // Helper: run a poll cycle with a specific SYSTEM_STATUS value
+  auto run_poll_with_status = [&](uint16_t status_val, uint32_t time_ms) {
+    set_millis(time_ms);
+    hub.update();
+    auto tx = hub.mock_get_transmitted();
+    REQUIRE(tx.size() > 0);
+    complete_tx(hub, time_ms);
+
+    size_t num_regs = (tx.size() - 4) / 2;
+    std::vector<std::pair<uint16_t, uint16_t>> resp_vals;
+    for (size_t i = 0; i < num_regs; i++) {
+      uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+      uint16_t val = 0;
+      if (addr == registers::SYSTEM_STATUS) val = status_val;
+      resp_vals.emplace_back(addr, val);
+    }
+    hub.mock_receive(make_response_42(resp_vals));
+    set_millis(time_ms + 50);
+    hub.loop();
+  };
+
+  SECTION("bits set (closed) → no problem (false)") {
+    // Both LPS (0x80) and HPS (0x100) bits set = switches closed = normal
+    run_poll_with_status(STATUS_LPS | STATUS_HPS, 200);
+    REQUIRE(lps.has_state_);
+    REQUIRE(lps.state == false);  // not a problem
+    REQUIRE(hps.has_state_);
+    REQUIRE(hps.state == false);  // not a problem
+  }
+
+  SECTION("bits clear (open) → problem (true)") {
+    // Both bits clear = switches open = fault condition
+    run_poll_with_status(0x0000, 200);
+    REQUIRE(lps.has_state_);
+    REQUIRE(lps.state == true);  // problem
+    REQUIRE(hps.has_state_);
+    REQUIRE(hps.state == true);  // problem
+  }
+
+  SECTION("only LPS open → LPS problem, HPS ok") {
+    // HPS bit set (0x100), LPS bit clear
+    run_poll_with_status(STATUS_HPS, 200);
+    REQUIRE(lps.state == true);   // LPS open = problem
+    REQUIRE(hps.state == false);  // HPS closed = ok
+  }
+
+  SECTION("only HPS open → HPS problem, LPS ok") {
+    // LPS bit set (0x80), HPS bit clear
+    run_poll_with_status(STATUS_LPS, 200);
+    REQUIRE(lps.state == false);  // LPS closed = ok
+    REQUIRE(hps.state == true);   // HPS open = problem
+  }
+}
+
+// ============================================================================
+// Entering Air Temperature Zero-Suppression
+// ============================================================================
+
+TEST_CASE("Entering air temperature suppresses zero values", "[hub][sensors]") {
+  WaterFurnaceAurora hub;
+  sensor::Sensor entering_air;
+  hub.set_entering_air_temperature_sensor(&entering_air);
+
+  set_millis(0);
+  drive_setup(hub);  // non-AWL system → reads register 567
+  REQUIRE(hub.is_setup_complete());
+
+  auto run_poll_with_entering_air = [&](uint16_t raw_val, uint32_t time_ms) {
+    set_millis(time_ms);
+    hub.update();
+    auto tx = hub.mock_get_transmitted();
+    REQUIRE(tx.size() > 0);
+    complete_tx(hub, time_ms);
+
+    size_t num_regs = (tx.size() - 4) / 2;
+    std::vector<std::pair<uint16_t, uint16_t>> resp_vals;
+    for (size_t i = 0; i < num_regs; i++) {
+      uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+      uint16_t val = 0;
+      if (addr == registers::ENTERING_AIR) val = raw_val;
+      resp_vals.emplace_back(addr, val);
+    }
+    hub.mock_receive(make_response_42(resp_vals));
+    set_millis(time_ms + 50);
+    hub.loop();
+  };
+
+  SECTION("zero value is not published") {
+    run_poll_with_entering_air(0, 200);
+    // Zero should be suppressed — sensor should not have state
+    REQUIRE_FALSE(entering_air.has_state_);
+  }
+
+  SECTION("non-zero value is published as signed tenths") {
+    // 698 = 69.8°F
+    run_poll_with_entering_air(698, 200);
+    REQUIRE(entering_air.has_state_);
+    REQUIRE(entering_air.state == Catch::Approx(69.8f));
+  }
+
+  SECTION("non-zero then zero does not overwrite") {
+    // First: valid reading
+    run_poll_with_entering_air(698, 200);
+    REQUIRE(entering_air.state == Catch::Approx(69.8f));
+    int count_after_first = entering_air.publish_count_;
+
+    // Second: zero — should not publish, value stays at 69.8
+    run_poll_with_entering_air(0, 300);
+    REQUIRE(entering_air.publish_count_ == count_after_first);
+    REQUIRE(entering_air.state == Catch::Approx(69.8f));
+  }
+}
+
+// ============================================================================
+// Outdoor Temperature Zero-Suppression
+// ============================================================================
+
+TEST_CASE("Outdoor temperature suppresses zero values", "[hub][sensors]") {
+  WaterFurnaceAurora hub;
+  sensor::Sensor outdoor_temp;
+  hub.set_outdoor_temperature_sensor(&outdoor_temp);
+
+  // Need AWL communicating to poll outdoor temp (register 742)
+  // drive_setup creates thermostat v3.00 which satisfies awl_thermostat()
+  set_millis(0);
+  drive_setup(hub);
+  REQUIRE(hub.is_setup_complete());
+
+  auto run_poll_with_outdoor = [&](uint16_t raw_val, uint32_t time_ms) {
+    set_millis(time_ms);
+    hub.update();
+    auto tx = hub.mock_get_transmitted();
+    REQUIRE(tx.size() > 0);
+    complete_tx(hub, time_ms);
+
+    size_t num_regs = (tx.size() - 4) / 2;
+    std::vector<std::pair<uint16_t, uint16_t>> resp_vals;
+    for (size_t i = 0; i < num_regs; i++) {
+      uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+      uint16_t val = 0;
+      if (addr == registers::OUTDOOR_TEMP) val = raw_val;
+      resp_vals.emplace_back(addr, val);
+    }
+    hub.mock_receive(make_response_42(resp_vals));
+    set_millis(time_ms + 50);
+    hub.loop();
+  };
+
+  SECTION("zero value is not published") {
+    run_poll_with_outdoor(0, 200);
+    REQUIRE_FALSE(outdoor_temp.has_state_);
+  }
+
+  SECTION("non-zero value is published") {
+    // 350 = 35.0°F
+    run_poll_with_outdoor(350, 200);
+    REQUIRE(outdoor_temp.has_state_);
+    REQUIRE(outdoor_temp.state == Catch::Approx(35.0f));
+  }
+}
+
+// ============================================================================
+// Approach Temperature Compressor Guard
+// ============================================================================
+
+TEST_CASE("Approach temperature requires compressor running", "[hub][sensors][derived]") {
+  WaterFurnaceAurora hub;
+  sensor::Sensor approach;
+  hub.set_approach_temperature_sensor(&approach);
+
+  // Need AXB for water temps, and refrigeration monitoring for sat condenser
+  hub.set_has_axb_override(true);
+
+  // Custom drive_setup with AXB + refrigeration monitoring
+  set_millis(0);
+  hub.setup();
+
+  // Step 1: ID request
+  hub.loop();
+  hub.mock_get_transmitted();
+  complete_tx(hub, 0);
+  std::vector<uint16_t> id_values(18, 0x2020);
+  hub.mock_receive(make_response_03(id_values));
+  set_millis(50);
+  hub.loop();
+
+  // Step 2: Detect request — AXB present, energy monitor level 1 (refrigeration)
+  hub.loop();
+  auto tx = hub.mock_get_transmitted();
+  size_t num_detect_regs = (tx.size() - 4) / 2;
+  std::vector<std::pair<uint16_t, uint16_t>> detect_vals;
+  for (size_t i = 0; i < num_detect_regs; i++) {
+    uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+    uint16_t val = 3;
+    if (addr == registers::THERMOSTAT_VERSION) val = 300;
+    if (addr == registers::AXB_VERSION) val = 200;  // AWL AXB v2.00
+    if (addr == registers::BLOWER_TYPE) val = 0;
+    if (addr == registers::ENERGY_MONITOR) val = 1;  // refrigeration monitoring
+    if (addr == registers::PUMP_TYPE) val = 0;
+    if (addr >= 88 && addr <= 91) val = 0x2020;
+    detect_vals.emplace_back(addr, val);
+  }
+  complete_tx(hub, 50);
+  hub.mock_receive(make_response_42(detect_vals));
+  set_millis(100);
+  hub.loop();
+
+  // Step 3: VS probe
+  hub.loop();
+  hub.loop();
+  hub.mock_get_transmitted();
+  complete_tx(hub, 100);
+  hub.mock_receive(make_response_42({{3001, 0}, {3322, 0}, {3325, 0}}));
+  set_millis(150);
+  hub.loop();
+  REQUIRE(hub.is_setup_complete());
+
+  auto run_poll = [&](uint16_t outputs, uint16_t sat_cond, uint16_t lwt,
+                      uint16_t ewt, uint32_t time_ms) {
+    set_millis(time_ms);
+    hub.update();
+    auto tx2 = hub.mock_get_transmitted();
+    REQUIRE(tx2.size() > 0);
+    complete_tx(hub, time_ms);
+
+    size_t num_regs = (tx2.size() - 4) / 2;
+    std::vector<std::pair<uint16_t, uint16_t>> resp_vals;
+    for (size_t i = 0; i < num_regs; i++) {
+      uint16_t addr = (tx2[2 + i * 2] << 8) | tx2[3 + i * 2];
+      uint16_t val = 0;
+      if (addr == registers::SYSTEM_OUTPUTS) val = outputs;
+      if (addr == registers::SATURATED_CONDENSER_TEMP) val = sat_cond;
+      if (addr == registers::LEAVING_WATER) val = lwt;
+      if (addr == registers::ENTERING_WATER) val = ewt;
+      resp_vals.emplace_back(addr, val);
+    }
+    hub.mock_receive(make_response_42(resp_vals));
+    set_millis(time_ms + 50);
+    hub.loop();
+  };
+
+  SECTION("compressor off → publishes NAN") {
+    // No CC/CC2 in outputs = compressor off
+    // sat_cond=500 (50.0), lwt=520 (52.0), ewt=480 (48.0)
+    run_poll(0x0000, 500, 520, 480, 200);
+    REQUIRE(approach.has_state_);
+    REQUIRE(std::isnan(approach.state));
+  }
+
+  SECTION("compressor on heating → publishes LWT - SatCond") {
+    // CC bit (0x01) set, no RV = heating mode
+    // sat_cond=500 (50.0°F), lwt=530 (53.0°F) → approach = 53.0 - 50.0 = 3.0
+    run_poll(OUTPUT_CC, 500, 530, 480, 200);
+    REQUIRE(approach.has_state_);
+    REQUIRE(approach.state == Catch::Approx(3.0f));
+  }
+
+  SECTION("compressor on cooling → publishes SatCond - EWT") {
+    // CC bit (0x01) + RV bit (0x04) = cooling mode
+    // sat_cond=500 (50.0°F), ewt=480 (48.0°F) → approach = 50.0 - 48.0 = 2.0
+    run_poll(OUTPUT_CC | OUTPUT_RV, 500, 530, 480, 200);
+    REQUIRE(approach.has_state_);
+    REQUIRE(approach.state == Catch::Approx(2.0f));
+  }
+
+  SECTION("transition from running to idle clears to NAN") {
+    // First: compressor running → valid approach
+    run_poll(OUTPUT_CC, 500, 530, 480, 200);
+    REQUIRE_FALSE(std::isnan(approach.state));
+
+    // Then: compressor off → NAN
+    run_poll(0x0000, 500, 530, 480, 300);
+    REQUIRE(std::isnan(approach.state));
+  }
+}
+
+// ============================================================================
 // VS Pump Manual Control
 // ============================================================================
 

--- a/tests/test_registers.cpp
+++ b/tests/test_registers.cpp
@@ -339,3 +339,101 @@ TEST_CASE("RegisterMap operations", "[registers][map]") {
     REQUIRE(*reg_find(map, 742) == 100);
   }
 }
+
+// ============================================================================
+// DIP Switch Parsing (register 33)
+// ============================================================================
+
+TEST_CASE("parse_dip_switches", "[registers][dip_switch]") {
+  SECTION("manual mode (0x7FFF)") {
+    auto ds = parse_dip_switches(0x7FFF);
+    REQUIRE(ds.manual == true);
+  }
+
+  SECTION("all zeros — default settings") {
+    auto ds = parse_dip_switches(0x0000);
+    REQUIRE(ds.manual == false);
+    REQUIRE(ds.fp1 == 15);        // bit 0 clear → 15
+    REQUIRE(ds.fp2 == 0);         // bit 1 clear → off (0)
+    REQUIRE(ds.reversing_valve == ReversingValveType::B_TYPE);  // bit 2 clear
+    REQUIRE(ds.accessory_relay == AccessoryRelay::COMPRESSOR);  // bits 3-4 = 0
+    REQUIRE(ds.compressor_stages == 2);  // bit 5 clear → dual stage
+    REQUIRE(ds.lockout == LockoutType::PULSE);  // bit 6 clear
+    REQUIRE(ds.dehumidifier_reheat == DehumidifierReheat::REHEAT);  // bit 7 clear
+  }
+
+  SECTION("all bits set (0xFF)") {
+    auto ds = parse_dip_switches(0xFF);
+    REQUIRE(ds.manual == false);
+    REQUIRE(ds.fp1 == 30);        // bit 0 set → 30
+    REQUIRE(ds.fp2 == 30);        // bit 1 set → 30
+    REQUIRE(ds.reversing_valve == ReversingValveType::O_TYPE);  // bit 2 set
+    REQUIRE(ds.accessory_relay == AccessoryRelay::BLOWER);  // bits 3-4 = 0b11 = 3
+    REQUIRE(ds.compressor_stages == 1);  // bit 5 set → single stage
+    REQUIRE(ds.lockout == LockoutType::CONTINUOUS);  // bit 6 set
+    REQUIRE(ds.dehumidifier_reheat == DehumidifierReheat::DEHUMIDIFIER);  // bit 7 set
+  }
+
+  SECTION("humidifier accessory relay (bits 3-4 = 0b10 = 2)") {
+    // bits 3-4 = 0b10 → value 2 → HUMIDIFIER
+    uint16_t value = 0x10;  // bit 4 set → (0x10 >> 3) & 3 = 2
+    auto ds = parse_dip_switches(value);
+    REQUIRE(ds.accessory_relay == AccessoryRelay::HUMIDIFIER);
+  }
+
+  SECTION("slow opening water valve (bits 3-4 = 0b01 = 1)") {
+    uint16_t value = 0x08;  // bit 3 set → (0x08 >> 3) & 3 = 1
+    auto ds = parse_dip_switches(value);
+    REQUIRE(ds.accessory_relay == AccessoryRelay::SLOW_OPENING_WATER_VALVE);
+  }
+
+  SECTION("dual stage compressor from bit 5 clear") {
+    auto ds = parse_dip_switches(0x00);  // bit 5 clear
+    REQUIRE(ds.compressor_stages == 2);
+  }
+
+  SECTION("single stage compressor from bit 5 set") {
+    auto ds = parse_dip_switches(0x20);  // bit 5 set
+    REQUIRE(ds.compressor_stages == 1);
+  }
+
+  SECTION("mixed realistic config — O-type RV, humidifier, single stage, continuous lockout") {
+    // bit 2 (RV O-type) | bit 4 (acc=humidifier) | bit 5 (single) | bit 6 (continuous)
+    uint16_t value = 0x04 | 0x10 | 0x20 | 0x40;
+    auto ds = parse_dip_switches(value);
+    REQUIRE(ds.reversing_valve == ReversingValveType::O_TYPE);
+    REQUIRE(ds.accessory_relay == AccessoryRelay::HUMIDIFIER);
+    REQUIRE(ds.compressor_stages == 1);
+    REQUIRE(ds.lockout == LockoutType::CONTINUOUS);
+    REQUIRE(ds.dehumidifier_reheat == DehumidifierReheat::REHEAT);
+  }
+}
+
+// ============================================================================
+// AXB Accessory Relay 2 Extraction (register 1103 bits 7-8)
+// ============================================================================
+
+TEST_CASE("axb_extract_accessory_relay2", "[registers][axb]") {
+  SECTION("neither bit set → DEHUMIDIFIER (default)") {
+    REQUIRE(axb_extract_accessory_relay2(0x000) == AxbAccessoryRelay2::DEHUMIDIFIER);
+  }
+
+  SECTION("bit 7 only → HIGH_CAPACITY_COMPRESSOR") {
+    REQUIRE(axb_extract_accessory_relay2(0x080) == AxbAccessoryRelay2::HIGH_CAPACITY_COMPRESSOR);
+  }
+
+  SECTION("bit 8 only → LOW_CAPACITY_COMPRESSOR") {
+    REQUIRE(axb_extract_accessory_relay2(0x100) == AxbAccessoryRelay2::LOW_CAPACITY_COMPRESSOR);
+  }
+
+  SECTION("both bits set → BLOWER") {
+    REQUIRE(axb_extract_accessory_relay2(0x180) == AxbAccessoryRelay2::BLOWER);
+  }
+
+  SECTION("other bits do not affect result") {
+    // Bits 0-6 set, but bits 7-8 clear → still DEHUMIDIFIER
+    REQUIRE(axb_extract_accessory_relay2(0x07F) == AxbAccessoryRelay2::DEHUMIDIFIER);
+    // Bits 0-6 and 9+ set, bits 7-8 = 0b10 → HIGH_CAPACITY_COMPRESSOR
+    REQUIRE(axb_extract_accessory_relay2(0x07F | 0x080 | 0x200) == AxbAccessoryRelay2::HIGH_CAPACITY_COMPRESSOR);
+  }
+}

--- a/tests/waterfurnace-test.yaml
+++ b/tests/waterfurnace-test.yaml
@@ -275,7 +275,7 @@ sensor:
     eev_superheat:
       name: "Test EEV Superheat"
     eev_open:
-      name: "Test EEV Open"
+      name: "Test EEV2 Open"
     eev_suction_temperature:
       name: "Test EEV Suction Temp"
     eev_saturated_suction_temperature:

--- a/tests/waterfurnace-test.yaml
+++ b/tests/waterfurnace-test.yaml
@@ -62,12 +62,23 @@ water_heater:
     name: "Test Domestic Hot Water"
     aurora_id: aurora
 
-# --- Climate (main thermostat) ---
+# --- Climate (main thermostat + IZ2 zone with diagnostics) ---
 climate:
   - platform: waterfurnace_aurora
     id: aurora_thermostat
     name: "Test Heat Pump"
     aurora_id: aurora
+  - platform: waterfurnace_aurora
+    id: aurora_zone2
+    name: "Test Zone 2"
+    aurora_id: aurora
+    zone: 2
+    zone_priority:
+      name: "Test Zone 2 Priority"
+    zone_size:
+      name: "Test Zone 2 Size"
+    zone_normalized_size:
+      name: "Test Zone 2 Normalized Size"
 
 # --- Switch ---
 switch:
@@ -75,6 +86,8 @@ switch:
     aurora_id: aurora
     dhw_enabled:
       name: "Test DHW Enabled"
+    test_mode:
+      name: "Test Test Mode"
 
 # --- Number controls ---
 number:
@@ -245,6 +258,30 @@ sensor:
       name: "Test Compressor 1 Amps"
     compressor_2_amps:
       name: "Test Compressor 2 Amps"
+    axb_leaving_air_temperature:
+      name: "Test AXB Leaving Air Temp"
+    axb_suction_temperature:
+      name: "Test AXB Suction Temp"
+    saturated_evaporator_temperature:
+      name: "Test Saturated Evaporator Temp"
+    axb_superheat:
+      name: "Test AXB Superheat"
+    vapor_injector_open:
+      name: "Test Vapor Injector Open"
+    eev_superheat:
+      name: "Test EEV Superheat"
+    eev_open:
+      name: "Test EEV Open"
+    eev_suction_temperature:
+      name: "Test EEV Suction Temp"
+    eev_saturated_suction_temperature:
+      name: "Test EEV Sat Suction Temp"
+    fault_e1:
+      name: "Test Fault E1 Count"
+    fault_e2:
+      name: "Test Fault E2 Count"
+    fault_e99:
+      name: "Test Fault E99 Count"
 
 # --- ALL Binary sensors ---
 binary_sensor:
@@ -321,6 +358,8 @@ text_sensor:
       name: "Test Outputs at Lockout"
     inputs_at_lockout:
       name: "Test Inputs at Lockout"
+    eev2_ctl:
+      name: "Test EEV2 Ctl"
 
 # --- Selects ---
 select:
@@ -330,6 +369,10 @@ select:
       name: "Test Humidifier Mode Select"
     dehumidifier_mode:
       name: "Test Dehumidifier Mode Select"
+    manual_operation:
+      name: "Test Manual Operation"
+      compressor_speed: 8
+      blower_speed: 255
 
 # --- Buttons ---
 button:

--- a/tests/waterfurnace-test.yaml
+++ b/tests/waterfurnace-test.yaml
@@ -115,6 +115,10 @@ number:
       name: "Test Humidification Setpoint"
     dehumidification_target:
       name: "Test Dehumidification Setpoint"
+    cooling_airflow_adjustment:
+      name: "Test Cooling Airflow Adjustment"
+    loop_pressure_trip:
+      name: "Test Loop Pressure Trip"
 
 # --- ALL Sensors (complete coverage) ---
 sensor:
@@ -276,6 +280,16 @@ sensor:
       name: "Test EEV Suction Temp"
     eev_saturated_suction_temperature:
       name: "Test EEV Sat Suction Temp"
+    # Configuration sensors (gap 11)
+    off_time_length:
+      name: "Test Off Time Length"
+    power_adj_factor_l:
+      name: "Test Power Adj Factor L"
+    power_adj_factor_h:
+      name: "Test Power Adj Factor H"
+    # Condensate monitoring (gap 13)
+    condensate:
+      name: "Test Condensate"
     fault_e1:
       name: "Test Fault E1 Count"
     fault_e2:
@@ -319,6 +333,13 @@ binary_sensor:
       name: "Test Safe Mode"
     diverting_valve:
       name: "Test Diverting Valve"
+    # Configuration triggers (gap 11)
+    smartgrid_trigger:
+      name: "Test SmartGrid Trigger"
+    ha_alarm_1_trigger:
+      name: "Test HA Alarm 1 Trigger"
+    ha_alarm_2_trigger:
+      name: "Test HA Alarm 2 Trigger"
 
 # --- ALL Text sensors ---
 text_sensor:
@@ -360,6 +381,42 @@ text_sensor:
       name: "Test Inputs at Lockout"
     eev2_ctl:
       name: "Test EEV2 Ctl"
+    # Configuration text sensors (gap 11)
+    brine_type:
+      name: "Test Brine Type"
+    flow_meter_type:
+      name: "Test Flow Meter Type"
+    smartgrid_action:
+      name: "Test SmartGrid Action"
+    ha_alarm_1_action:
+      name: "Test HA Alarm 1 Action"
+    ha_alarm_2_action:
+      name: "Test HA Alarm 2 Action"
+    energy_phase_type:
+      name: "Test Energy Phase Type"
+    # VS Drive 3200-range duplicates (gap 14)
+    vs_drive_derate_alt:
+      name: "Test VS Drive Derate Alt"
+    vs_drive_safe_mode_alt:
+      name: "Test VS Drive Safe Mode Alt"
+    vs_drive_alarm_alt:
+      name: "Test VS Drive Alarm Alt"
+    # VS Drive EEV2 Ctl (gap 15)
+    vs_drive_eev2_ctl:
+      name: "Test VS Drive EEV2 Ctl"
+    # Dealer information (gap 19)
+    dealer_name:
+      name: "Test Dealer Name"
+    dealer_phone:
+      name: "Test Dealer Phone"
+    dealer_address_1:
+      name: "Test Dealer Address 1"
+    dealer_address_2:
+      name: "Test Dealer Address 2"
+    dealer_email:
+      name: "Test Dealer Email"
+    dealer_website:
+      name: "Test Dealer Website"
 
 # --- Selects ---
 select:

--- a/waterfurnace_aurora.yaml
+++ b/waterfurnace_aurora.yaml
@@ -147,6 +147,7 @@ number:
     # dhw_setpoint:
     #   name: "DHW Setpoint"
     # Indoor Blower/ECM speed settings (1-12)
+    # NOTE: Requires ECM blower (blower type 1 or 2). Shows "Unknown" on PSC/5-speed blowers.
     blower_only_speed:
       name: "Indoor Blower Only Speed"
     lo_compressor_speed:
@@ -156,6 +157,7 @@ number:
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed"
     # Loop Pump speed settings (1-100%)
+    # NOTE: Requires variable speed (VS) pump. Shows "Unknown" on fixed-speed pumps.
     pump_min_speed:
       name: "Loop Pump Minimum Speed"
     pump_max_speed:
@@ -183,13 +185,13 @@ sensor:
     aurora_id: aurora
     
     # Air temperatures
-    entering_air_temperature:
+    entering_air_temperature:  # reads register 740 (AWL AXB) or 567 (non-AWL); suppresses 0 values
       name: "Return Air Temperature"
-    leaving_air_temperature:  # requires AWL AXB (AXB firmware >= v2.0)
+    leaving_air_temperature:  # requires AWL AXB (AXB firmware >= v2.0); shows "Unknown" otherwise
       name: "Supply Air Temperature"
     ambient_temperature:
       name: "Ambient Temperature"
-    outdoor_temperature:
+    outdoor_temperature:  # requires AWL communicating thermostat; suppresses 0 values
       name: "Outdoor Temperature"
     
     # Water/loop temperatures
@@ -220,15 +222,15 @@ sensor:
     compressor_desired_speed:
       name: "Compressor Desired Speed"
     
-    # Pressures
+    # Pressures (requires VS drive for discharge/suction; AXB for loop pressure)
     discharge_pressure:
       name: "Discharge Pressure"
     suction_pressure:
       name: "Suction Pressure"
-    loop_pressure:
+    loop_pressure:  # requires AXB board with pressure sensor hardware
       name: "Loop Pressure"
     
-    # Refrigeration
+    # Refrigeration (requires VS drive; requires refrigeration monitoring for liquid line/subcool)
     eev_open_percentage:
       name: "EEV Open Percentage"
     superheat_temperature:
@@ -248,7 +250,7 @@ sensor:
     fp2_temperature:
       name: "FP2 Temperature"
     
-    # VS Drive temperatures
+    # VS Drive temperatures (requires VS drive; shows "Unknown" on non-VS systems)
     vs_drive_temperature:
       name: "VS Drive Temperature"
     vs_inverter_temperature:
@@ -258,7 +260,7 @@ sensor:
     saturated_evaporator_discharge_temperature:
       name: "Saturated Evaporator Discharge Temperature"
     
-    # VS Drive additional
+    # VS Drive additional (requires VS drive)
     vs_fan_speed:
       name: "VS Fan Speed"
     vs_compressor_watts:
@@ -268,7 +270,7 @@ sensor:
     aux_heat_stage:
       name: "Aux Electric Heat Stage"
     
-    # Energy / Power
+    # Energy / Power (requires energy monitoring level >= 2)
     line_voltage:
       name: "Line Voltage"
     total_watts:
@@ -291,6 +293,8 @@ sensor:
       name: "Loop Flow Rate"
     
     # Indoor Blower/ECM speeds
+    # NOTE: blower_speed works for all blower types (ECM reads register, others derive from outputs).
+    # The _setting sensors require ECM blower (type 1 or 2); show "Unknown" on PSC/5-speed.
     blower_speed:
       name: "Indoor Blower Speed"
     blower_only_speed:
@@ -302,7 +306,7 @@ sensor:
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed Setting"
     
-    # Loop Pump speeds
+    # Loop Pump speeds (requires variable speed pump; show "Unknown" on fixed-speed pumps)
     pump_speed:
       name: "Loop Pump Speed"
     pump_min_speed:
@@ -328,12 +332,12 @@ sensor:
     # iz2_unit_demand:
     #   name: "IZ2 Unit Demand"
     
-    # Derived sensors (computed on-device)
-    cop:
+    # Derived sensors (computed on-device; require underlying registers to be available)
+    cop:  # requires energy monitoring + compressor running; shows 0 when idle
       name: "Coefficient of Performance"
-    water_delta_t:
+    water_delta_t:  # requires AXB (leaving/entering water temps)
       name: "Water Delta-T"
-    approach_temperature:
+    approach_temperature:  # requires refrigeration monitoring + compressor running; "Unknown" when idle
       name: "Approach Temperature"
 
 # =============================================================================
@@ -404,7 +408,7 @@ text_sensor:
     serial_number:
       name: "Serial Number"
     
-    # VS Drive status
+    # VS Drive status (requires VS drive; show "Unknown" on non-VS systems)
     vs_derate:
       name: "VS Drive Derate"
     vs_safe_mode:


### PR DESCRIPTION
## Summary

Closes parity gaps with the Ruby gem and fixes several user-reported bugs (ref: #18 by @0n3man). +2163 / -231 lines across 28 files, 438 test assertions passing with ASan+UBSan.

## Bug Fixes

- **Pressure switch polarity inverted** - High/Low Pressure Switch showed "Problem" when normal. Bit set = closed (normal), not fault.
- **Approach temperature below -40°F** - Heating-mode formula used wrong heat exchanger; fixed to `sat_cond - leaving_air`. Also gated on compressor running to avoid garbage values when idle.
- **Subcool / Water Delta-T sign** - ABC stores with sign; now uses `std::abs()` since magnitude is what matters for diagnostics.
- **Return Air / Outdoor Temperature showing 0.0°F** - Added zero-suppression matching the Ruby gem's behavior for non-AWL systems.
- **Fault history reads** - Fixed Modbus function code (0x41 not standard read).
- **Poll overflow >100 registers** - Split into two ABC requests with bounds-checked `add_poll_addr_()`.
- **Chained request state** - Don't clear `pending_request_` when handler chains to a new request.
- **Power failure recovery (Issue #17)** - When ESP32 boots before the heat pump, it now triggers a full hardware re-detection on the first successful poll. Previously, it would load defaults and never recover until rebooted.
- **Modbus timeout diagnostics** - Added hex dump of the receive buffer when a response timeout occurs, to help diagnose the truncation issue reported in #17

## New Features: Ruby Gem Parity (Gaps 1-15, 19)

**Hardware detection (gaps 1-4):**
- DIP switch parsing (register 33) - compressor stages, humidifier, freeze protection thresholds, reversing valve type
- Non-VS compressor speed derived from CC/CC2 output bits
- 5-speed blower speed derived from system output bits
- Proper humidistat presence detection (ABC DIP + AXB accessory relay 2)

**Diagnostic sensors (gaps 5-7):**
- AXB registers: leaving air, suction temp, saturated evaporator, superheat, vapor injector open %
- EEV2 registers: superheat, open %, suction temp, saturated suction, control bitmask
- AXB current sensors: blower/aux/compressor 1&2 amps

**Controls (gap 8):**
- Manual operation select (Off/Heating/Cooling/Heating+Aux -> register 3002)
- Test mode switch (register 45)

**Counters & zone data (gaps 9-10):**
- E1-E99 individual fault history counters (`state_class: total_increasing`)
- IZ2 per-zone priority, size, normalized size sensors

**Configuration & info (gaps 11-15, 19):**
- Config registers: brine type, flow meter, SmartGrid, HA alarms, energy phase, power adjustment factors
- Writable entities: loop pressure trip (reg 419), cooling airflow adjustment (reg 346)
- Condensate monitor (reg 21), VS 3200-range alt diagnostics, dealer info strings

## Other

- C++20 (`gnu++20`)
- 98 new register/DIP-switch test assertions, 293 new hub test lines
- Test YAML exercises all new entity code paths
- 