### PR TITLE
BREAKING: Rename entity YAML keys for upstream gem parity

### DIFF
--- a/components/waterfurnace_aurora/binary_sensor/__init__.py
+++ b/components/waterfurnace_aurora/binary_sensor/__init__.py
@@ -29,7 +29,7 @@ BINARY_SENSORS = {
     "loop_pump_running": binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_RUNNING,
     ),
-    "lockout": binary_sensor.binary_sensor_schema(
+    "locked_out": binary_sensor.binary_sensor_schema(
         device_class=DEVICE_CLASS_PROBLEM,
     ),
     "humidifier_running": binary_sensor.binary_sensor_schema(

--- a/components/waterfurnace_aurora/number/__init__.py
+++ b/components/waterfurnace_aurora/number/__init__.py
@@ -26,8 +26,8 @@ CODEOWNERS = ["@daemonp"]
 # Configuration keys
 CONF_DHW_SETPOINT = "dhw_setpoint"
 CONF_BLOWER_ONLY_SPEED = "blower_only_speed"
-CONF_LO_COMPRESSOR_SPEED = "lo_compressor_speed"
-CONF_HI_COMPRESSOR_SPEED = "hi_compressor_speed"
+CONF_LOW_COMPRESSOR_SPEED = "low_compressor_speed"
+CONF_HIGH_COMPRESSOR_SPEED = "high_compressor_speed"
 CONF_AUX_HEAT_SPEED = "aux_heat_speed"
 CONF_PUMP_SPEED = "pump_speed"
 CONF_PUMP_MIN_SPEED = "pump_min_speed"
@@ -52,8 +52,8 @@ AuroraNumberType = waterfurnace_aurora_ns.enum("AuroraNumberType", is_class=True
 # Number type enum values
 AURORA_NUMBER_TYPES = {
     CONF_BLOWER_ONLY_SPEED: AuroraNumberType.BLOWER_ONLY_SPEED,
-    CONF_LO_COMPRESSOR_SPEED: AuroraNumberType.LO_COMPRESSOR_SPEED,
-    CONF_HI_COMPRESSOR_SPEED: AuroraNumberType.HI_COMPRESSOR_SPEED,
+    CONF_LOW_COMPRESSOR_SPEED: AuroraNumberType.LO_COMPRESSOR_SPEED,
+    CONF_HIGH_COMPRESSOR_SPEED: AuroraNumberType.HI_COMPRESSOR_SPEED,
     CONF_AUX_HEAT_SPEED: AuroraNumberType.AUX_HEAT_SPEED,
     CONF_PUMP_SPEED: AuroraNumberType.PUMP_SPEED,
     CONF_PUMP_MIN_SPEED: AuroraNumberType.PUMP_MIN_SPEED,
@@ -152,8 +152,8 @@ CONFIG_SCHEMA = cv.Schema(
         ).extend(cv.COMPONENT_SCHEMA),
         # Blower speed settings
         cv.Optional(CONF_BLOWER_ONLY_SPEED): BLOWER_SPEED_SCHEMA,
-        cv.Optional(CONF_LO_COMPRESSOR_SPEED): BLOWER_SPEED_SCHEMA,
-        cv.Optional(CONF_HI_COMPRESSOR_SPEED): BLOWER_SPEED_SCHEMA,
+        cv.Optional(CONF_LOW_COMPRESSOR_SPEED): BLOWER_SPEED_SCHEMA,
+        cv.Optional(CONF_HIGH_COMPRESSOR_SPEED): BLOWER_SPEED_SCHEMA,
         cv.Optional(CONF_AUX_HEAT_SPEED): BLOWER_SPEED_SCHEMA,
         # Pump speed settings
         cv.Optional(CONF_PUMP_SPEED): PUMP_SPEED_SCHEMA,

--- a/components/waterfurnace_aurora/registers.h
+++ b/components/waterfurnace_aurora/registers.h
@@ -137,8 +137,8 @@ namespace registers {
   static constexpr uint16_t ABC_VERSION = 2;
   static constexpr uint16_t COMPRESSOR_ANTI_SHORT_CYCLE = 6;
   static constexpr uint16_t LINE_VOLTAGE = 16;
-  static constexpr uint16_t FP1_TEMP = 19;
-  static constexpr uint16_t FP2_TEMP = 20;
+  static constexpr uint16_t FP1_TEMP = 19;                // Cooling liquid line temperature (FP1)
+  static constexpr uint16_t FP2_TEMP = 20;                // Air coil temperature (FP2)
   static constexpr uint16_t LAST_FAULT = 25;
   static constexpr uint16_t LAST_LOCKOUT_FAULT = 26;     // High bit = locked, bits 0-14 = fault code
   static constexpr uint16_t OUTPUTS_AT_LOCKOUT = 27;     // Bitmask: system outputs when lockout occurred

--- a/components/waterfurnace_aurora/sensor/__init__.py
+++ b/components/waterfurnace_aurora/sensor/__init__.py
@@ -90,18 +90,18 @@ SENSORS = {
     "dhw_temperature": TEMPERATURE_SENSOR_SCHEMA,
     "dhw_setpoint": TEMPERATURE_SENSOR_SCHEMA,
     "superheat_temperature": TEMPERATURE_SENSOR_SCHEMA,
-    "fp1_temperature": TEMPERATURE_SENSOR_SCHEMA,
-    "fp2_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "cooling_liquid_line_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "air_coil_temperature": TEMPERATURE_SENSOR_SCHEMA,
     "discharge_temperature": TEMPERATURE_SENSOR_SCHEMA,
     "suction_temperature": TEMPERATURE_SENSOR_SCHEMA,
-    "vs_drive_temperature": TEMPERATURE_SENSOR_SCHEMA,
-    "vs_inverter_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "compressor_drive_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "compressor_inverter_temperature": TEMPERATURE_SENSOR_SCHEMA,
     "heating_liquid_line_temperature": TEMPERATURE_SENSOR_SCHEMA,
     "saturated_condenser_temperature": TEMPERATURE_SENSOR_SCHEMA,
     "subcool_temperature": TEMPERATURE_SENSOR_SCHEMA,
-    "vs_ambient_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "compressor_ambient_temperature": TEMPERATURE_SENSOR_SCHEMA,
     "saturated_evaporator_discharge_temperature": TEMPERATURE_SENSOR_SCHEMA,
-    "vs_entering_water_temperature": TEMPERATURE_SENSOR_SCHEMA,
+    "compressor_entering_water_temperature": TEMPERATURE_SENSOR_SCHEMA,
     # Derived temperature sensors
     "water_delta_t": TEMPERATURE_SENSOR_SCHEMA,
     "approach_temperature": TEMPERATURE_SENSOR_SCHEMA,
@@ -127,16 +127,16 @@ SENSORS = {
     ),
     # Voltage
     "line_voltage": VOLTAGE_SENSOR_SCHEMA,
-    "vs_line_voltage": VOLTAGE_SENSOR_SCHEMA,
-    "vs_supply_voltage": VOLTAGE_SENSOR_SCHEMA,
-    "vs_udc_voltage": VOLTAGE_SENSOR_SCHEMA,
+    "compressor_line_voltage": VOLTAGE_SENSOR_SCHEMA,
+    "compressor_supply_voltage": VOLTAGE_SENSOR_SCHEMA,
+    "compressor_udc_voltage": VOLTAGE_SENSOR_SCHEMA,
     # Power sensors
     "total_watts": POWER_SENSOR_SCHEMA,
     "compressor_watts": POWER_SENSOR_SCHEMA,
     "blower_watts": POWER_SENSOR_SCHEMA,
     "aux_heat_watts": POWER_SENSOR_SCHEMA,
     "pump_watts": POWER_SENSOR_SCHEMA,
-    "vs_compressor_watts": POWER_SENSOR_SCHEMA,
+    "compressor_drive_watts": POWER_SENSOR_SCHEMA,
     # Flow
     "waterflow": sensor.sensor_schema(
         unit_of_measurement=UNIT_GPM,
@@ -170,8 +170,8 @@ SENSORS = {
     # Blower/ECM sensors
     "blower_speed": SPEED_SENSOR_SCHEMA,
     "blower_only_speed": SPEED_SENSOR_SCHEMA,
-    "lo_compressor_speed": SPEED_SENSOR_SCHEMA,
-    "hi_compressor_speed": SPEED_SENSOR_SCHEMA,
+    "low_compressor_speed": SPEED_SENSOR_SCHEMA,
+    "high_compressor_speed": SPEED_SENSOR_SCHEMA,
     "aux_heat_speed": SPEED_SENSOR_SCHEMA,
     # VS Pump sensors
     "pump_speed": PERCENT_SENSOR_SCHEMA,
@@ -188,10 +188,10 @@ SENSORS = {
         accuracy_decimals=0,
         state_class=STATE_CLASS_MEASUREMENT,
     ),
-    # Additional VS Drive sensors
-    "vs_fan_speed": PERCENT_SENSOR_SCHEMA,
+    # Additional compressor drive sensors
+    "compressor_fan_speed": PERCENT_SENSOR_SCHEMA,
     "aux_heat_stage": SPEED_SENSOR_SCHEMA,
-    "vs_thermo_power": PERCENT_SENSOR_SCHEMA,
+    "compressor_thermo_power": PERCENT_SENSOR_SCHEMA,
     # AXB current sensors
     "blower_amps": CURRENT_SENSOR_SCHEMA,
     "aux_amps": CURRENT_SENSOR_SCHEMA,

--- a/components/waterfurnace_aurora/text_sensor/__init__.py
+++ b/components/waterfurnace_aurora/text_sensor/__init__.py
@@ -22,9 +22,9 @@ TEXT_SENSORS = {
     "model_number": DIAGNOSTIC_TEXT_SCHEMA,
     "serial_number": DIAGNOSTIC_TEXT_SCHEMA,
     "fault_history": DIAGNOSTIC_TEXT_SCHEMA,
-    "vs_derate": DIAGNOSTIC_TEXT_SCHEMA,
-    "vs_safe_mode": DIAGNOSTIC_TEXT_SCHEMA,
-    "vs_alarm": DIAGNOSTIC_TEXT_SCHEMA,
+    "compressor_derate": DIAGNOSTIC_TEXT_SCHEMA,
+    "compressor_safe_mode": DIAGNOSTIC_TEXT_SCHEMA,
+    "compressor_alarm": DIAGNOSTIC_TEXT_SCHEMA,
     "axb_inputs": DIAGNOSTIC_TEXT_SCHEMA,
     "humidifier_mode": text_sensor.text_sensor_schema(),
     "dehumidifier_mode": text_sensor.text_sensor_schema(),
@@ -40,12 +40,12 @@ TEXT_SENSORS = {
     "ha_alarm_1_action": DIAGNOSTIC_TEXT_SCHEMA,
     "ha_alarm_2_action": DIAGNOSTIC_TEXT_SCHEMA,
     "energy_phase_type": DIAGNOSTIC_TEXT_SCHEMA,
-    # VS Drive 3200-range duplicates (gap 14)
-    "vs_drive_derate_alt": DIAGNOSTIC_TEXT_SCHEMA,
-    "vs_drive_safe_mode_alt": DIAGNOSTIC_TEXT_SCHEMA,
-    "vs_drive_alarm_alt": DIAGNOSTIC_TEXT_SCHEMA,
-    # VS Drive EEV2 Ctl (gap 15)
-    "vs_drive_eev2_ctl": DIAGNOSTIC_TEXT_SCHEMA,
+    # Compressor drive 3200-range alt diagnostics (gap 14)
+    "compressor_derate_alt": DIAGNOSTIC_TEXT_SCHEMA,
+    "compressor_safe_mode_alt": DIAGNOSTIC_TEXT_SCHEMA,
+    "compressor_alarm_alt": DIAGNOSTIC_TEXT_SCHEMA,
+    # Compressor drive EEV2 Ctl (gap 15)
+    "compressor_eev2_ctl": DIAGNOSTIC_TEXT_SCHEMA,
     # Dealer information (gap 19)
     "dealer_name": DIAGNOSTIC_TEXT_SCHEMA,
     "dealer_phone": DIAGNOSTIC_TEXT_SCHEMA,

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -921,10 +921,10 @@ void WaterFurnaceAurora::build_poll_addresses_() {
     this->add_poll_addr_(registers::VS_SUCTION_TEMP);
     this->add_poll_addr_(registers::VS_SAT_EVAP_DISCHARGE_TEMP);
     this->add_poll_addr_(registers::VS_SUPERHEAT_TEMP);
-    // VS Drive additional diagnostics — only poll if at least one sensor is configured
-    if (this->vs_entering_water_temperature_sensor_ || this->vs_line_voltage_sensor_ ||
-        this->vs_thermo_power_sensor_ || this->vs_supply_voltage_sensor_ ||
-        this->vs_udc_voltage_sensor_) {
+    // Compressor drive additional diagnostics — only poll if at least one sensor is configured
+    if (this->compressor_entering_water_temperature_sensor_ || this->compressor_line_voltage_sensor_ ||
+        this->compressor_thermo_power_sensor_ || this->compressor_supply_voltage_sensor_ ||
+        this->compressor_udc_voltage_sensor_) {
       this->add_poll_addr_(registers::VS_ENTERING_WATER_TEMP);
       this->add_poll_addr_(registers::VS_LINE_VOLTAGE);
       this->add_poll_addr_(registers::VS_THERMO_POWER);
@@ -1063,17 +1063,17 @@ void WaterFurnaceAurora::build_poll_addresses_() {
       this->add_poll_addr_(registers::CONDENSATE);
     }
 
-    // VS Drive 3200-range duplicates (gap 14) — only poll if any alt sensor is configured
-    if (this->has_vs_drive_ && (this->vs_drive_derate_alt_sensor_ || this->vs_drive_safe_mode_alt_sensor_ ||
-                                 this->vs_drive_alarm_alt_sensor_)) {
+    // Compressor drive 3200-range duplicates (gap 14) — only poll if any alt sensor is configured
+    if (this->has_vs_drive_ && (this->compressor_derate_alt_sensor_ || this->compressor_safe_mode_alt_sensor_ ||
+                                 this->compressor_alarm_alt_sensor_)) {
       this->add_poll_addr_(registers::VS_DRIVE_DERATE_ALT);
       this->add_poll_addr_(registers::VS_DRIVE_SAFE_MODE_ALT);
       this->add_poll_addr_(registers::VS_DRIVE_ALARM1_ALT);
       this->add_poll_addr_(registers::VS_DRIVE_ALARM2_ALT);
     }
 
-    // VS Drive EEV2 Ctl (gap 15) — only poll if sensor is configured
-    if (this->has_vs_drive_ && this->vs_drive_eev2_ctl_sensor_) {
+    // Compressor drive EEV2 Ctl (gap 15) — only poll if sensor is configured
+    if (this->has_vs_drive_ && this->compressor_eev2_ctl_sensor_) {
       this->add_poll_addr_(registers::VS_DRIVE_EEV2_CTL);
     }
 
@@ -1311,7 +1311,7 @@ void WaterFurnaceAurora::publish_all_sensors_() {
   this->publish_temperature_sensors_(regs);
   this->publish_mode_sensors_(regs);
   this->publish_power_loop_sensors_(regs);
-  this->publish_vs_drive_sensors_(regs);
+  this->publish_compressor_drive_sensors_(regs);
   this->publish_equipment_sensors_(regs);
   this->publish_config_sensors_(regs);
   this->publish_humidity_control_sensors_(regs);
@@ -1337,7 +1337,7 @@ void WaterFurnaceAurora::publish_fault_sensors_(const RegisterMap &regs) {
         this->fault_code_sensor_->publish_state(this->current_fault_);
       this->publish_text_if_changed(this->fault_description_sensor_, this->cached_fault_description_,
                                      get_fault_description(this->current_fault_));
-      publish_binary_if_changed_(this->lockout_sensor_, this->locked_out_);
+      publish_binary_if_changed_(this->locked_out_sensor_, this->locked_out_);
       // Derated: fault codes 41-46 (gem: abc_client.rb line 248)
       publish_binary_if_changed_(this->derated_sensor_,
                                  this->current_fault_ >= 41 && this->current_fault_ <= 46);
@@ -1594,7 +1594,7 @@ void WaterFurnaceAurora::publish_power_loop_sensors_(const RegisterMap &regs) {
   }
 }
 
-void WaterFurnaceAurora::publish_vs_drive_sensors_(const RegisterMap &regs) {
+void WaterFurnaceAurora::publish_compressor_drive_sensors_(const RegisterMap &regs) {
   // Compressor speed — source depends on whether VS drive is present.
   // VS Drive: read directly from register 3001 (actual speed, 0-12 Hz).
   // Non-VS (Generic): derive from system outputs register 30, per Ruby gem
@@ -1618,19 +1618,19 @@ void WaterFurnaceAurora::publish_vs_drive_sensors_(const RegisterMap &regs) {
   this->publish_sensor(regs, registers::COMPRESSOR_SPEED_DESIRED, this->compressor_desired_speed_sensor_);
   this->publish_sensor_signed_tenths(regs, registers::VS_DISCHARGE_TEMP, this->discharge_temperature_sensor_);
   this->publish_sensor_signed_tenths(regs, registers::VS_SUCTION_TEMP, this->suction_temperature_sensor_);
-  this->publish_sensor_signed_tenths(regs, registers::VS_DRIVE_TEMP, this->vs_drive_temperature_sensor_);
-  this->publish_sensor_signed_tenths(regs, registers::VS_INVERTER_TEMP, this->vs_inverter_temperature_sensor_);
-  this->publish_sensor(regs, registers::VS_FAN_SPEED, this->vs_fan_speed_sensor_);
-  this->publish_sensor_signed_tenths(regs, registers::VS_AMBIENT_TEMP, this->vs_ambient_temperature_sensor_);
-  this->publish_sensor_uint32(regs, registers::VS_COMPRESSOR_WATTS, this->vs_compressor_watts_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::VS_DRIVE_TEMP, this->compressor_drive_temperature_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::VS_INVERTER_TEMP, this->compressor_inverter_temperature_sensor_);
+  this->publish_sensor(regs, registers::VS_FAN_SPEED, this->compressor_fan_speed_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::VS_AMBIENT_TEMP, this->compressor_ambient_temperature_sensor_);
+  this->publish_sensor_uint32(regs, registers::VS_COMPRESSOR_WATTS, this->compressor_drive_watts_sensor_);
   this->publish_sensor_signed_tenths(regs, registers::VS_SAT_EVAP_DISCHARGE_TEMP, this->saturated_evaporator_discharge_temperature_sensor_);
   
-  // VS Drive additional diagnostics
-  this->publish_sensor_signed_tenths(regs, registers::VS_ENTERING_WATER_TEMP, this->vs_entering_water_temperature_sensor_);
-  this->publish_sensor(regs, registers::VS_LINE_VOLTAGE, this->vs_line_voltage_sensor_);
-  this->publish_sensor(regs, registers::VS_THERMO_POWER, this->vs_thermo_power_sensor_);
-  this->publish_sensor_uint32(regs, registers::VS_SUPPLY_VOLTAGE, this->vs_supply_voltage_sensor_);
-  this->publish_sensor(regs, registers::VS_UDC_VOLTAGE, this->vs_udc_voltage_sensor_);
+  // Compressor drive additional diagnostics
+  this->publish_sensor_signed_tenths(regs, registers::VS_ENTERING_WATER_TEMP, this->compressor_entering_water_temperature_sensor_);
+  this->publish_sensor(regs, registers::VS_LINE_VOLTAGE, this->compressor_line_voltage_sensor_);
+  this->publish_sensor(regs, registers::VS_THERMO_POWER, this->compressor_thermo_power_sensor_);
+  this->publish_sensor_uint32(regs, registers::VS_SUPPLY_VOLTAGE, this->compressor_supply_voltage_sensor_);
+  this->publish_sensor(regs, registers::VS_UDC_VOLTAGE, this->compressor_udc_voltage_sensor_);
   
   // AXB current sensors (tenths of amps)
   this->publish_sensor_tenths(regs, registers::AXB_BLOWER_AMPS, this->blower_amps_sensor_);
@@ -1638,21 +1638,21 @@ void WaterFurnaceAurora::publish_vs_drive_sensors_(const RegisterMap &regs) {
   this->publish_sensor_tenths(regs, registers::AXB_COMPRESSOR1_AMPS, this->compressor_1_amps_sensor_);
   this->publish_sensor_tenths(regs, registers::AXB_COMPRESSOR2_AMPS, this->compressor_2_amps_sensor_);
   
-  // VS Drive status strings — guard with raw register comparison to avoid
+  // Compressor drive status strings — guard with raw register comparison to avoid
   // bitmask_to_string() heap allocation when the underlying register is unchanged.
   {
     const uint16_t *val = reg_find(regs, registers::VS_DERATE);
-    if (val && *val != this->cached_vs_derate_raw_) {
-      this->cached_vs_derate_raw_ = *val;
-      this->publish_text_if_changed(this->vs_derate_sensor_, this->cached_vs_derate_,
+    if (val && *val != this->cached_compressor_derate_raw_) {
+      this->cached_compressor_derate_raw_ = *val;
+      this->publish_text_if_changed(this->compressor_derate_sensor_, this->cached_compressor_derate_,
                                       get_vs_derate_string(*val));
     }
   }
   {
     const uint16_t *val = reg_find(regs, registers::VS_SAFE_MODE);
-    if (val && *val != this->cached_vs_safe_mode_raw_) {
-      this->cached_vs_safe_mode_raw_ = *val;
-      this->publish_text_if_changed(this->vs_safe_mode_sensor_, this->cached_vs_safe_mode_,
+    if (val && *val != this->cached_compressor_safe_mode_raw_) {
+      this->cached_compressor_safe_mode_raw_ = *val;
+      this->publish_text_if_changed(this->compressor_safe_mode_sensor_, this->cached_compressor_safe_mode_,
                                       get_vs_safe_mode_string(*val));
     }
   }
@@ -1660,28 +1660,28 @@ void WaterFurnaceAurora::publish_vs_drive_sensors_(const RegisterMap &regs) {
     const uint16_t *val_a1 = reg_find(regs, registers::VS_ALARM1);
     const uint16_t *val_a2 = reg_find(regs, registers::VS_ALARM2);
     if (val_a1 && val_a2 &&
-        (*val_a1 != this->cached_vs_alarm1_raw_ || *val_a2 != this->cached_vs_alarm2_raw_)) {
-      this->cached_vs_alarm1_raw_ = *val_a1;
-      this->cached_vs_alarm2_raw_ = *val_a2;
-      this->publish_text_if_changed(this->vs_alarm_sensor_, this->cached_vs_alarm_,
+        (*val_a1 != this->cached_compressor_alarm1_raw_ || *val_a2 != this->cached_compressor_alarm2_raw_)) {
+      this->cached_compressor_alarm1_raw_ = *val_a1;
+      this->cached_compressor_alarm2_raw_ = *val_a2;
+      this->publish_text_if_changed(this->compressor_alarm_sensor_, this->cached_compressor_alarm_,
                                       get_vs_alarm_string(*val_a1, *val_a2));
     }
   }
 
-  // VS Drive 3200-range duplicate status strings (gap 14)
+  // Compressor drive 3200-range duplicate status strings (gap 14)
   {
     const uint16_t *val = reg_find(regs, registers::VS_DRIVE_DERATE_ALT);
-    if (val && *val != this->cached_vs_drive_derate_alt_raw_) {
-      this->cached_vs_drive_derate_alt_raw_ = *val;
-      this->publish_text_if_changed(this->vs_drive_derate_alt_sensor_, this->cached_vs_drive_derate_alt_,
+    if (val && *val != this->cached_compressor_derate_alt_raw_) {
+      this->cached_compressor_derate_alt_raw_ = *val;
+      this->publish_text_if_changed(this->compressor_derate_alt_sensor_, this->cached_compressor_derate_alt_,
                                       get_vs_derate_string(*val));
     }
   }
   {
     const uint16_t *val = reg_find(regs, registers::VS_DRIVE_SAFE_MODE_ALT);
-    if (val && *val != this->cached_vs_drive_safe_mode_alt_raw_) {
-      this->cached_vs_drive_safe_mode_alt_raw_ = *val;
-      this->publish_text_if_changed(this->vs_drive_safe_mode_alt_sensor_, this->cached_vs_drive_safe_mode_alt_,
+    if (val && *val != this->cached_compressor_safe_mode_alt_raw_) {
+      this->cached_compressor_safe_mode_alt_raw_ = *val;
+      this->publish_text_if_changed(this->compressor_safe_mode_alt_sensor_, this->cached_compressor_safe_mode_alt_,
                                       get_vs_safe_mode_string(*val));
     }
   }
@@ -1689,10 +1689,10 @@ void WaterFurnaceAurora::publish_vs_drive_sensors_(const RegisterMap &regs) {
     const uint16_t *val_a1 = reg_find(regs, registers::VS_DRIVE_ALARM1_ALT);
     const uint16_t *val_a2 = reg_find(regs, registers::VS_DRIVE_ALARM2_ALT);
     if (val_a1 && val_a2 &&
-        (*val_a1 != this->cached_vs_drive_alarm1_alt_raw_ || *val_a2 != this->cached_vs_drive_alarm2_alt_raw_)) {
-      this->cached_vs_drive_alarm1_alt_raw_ = *val_a1;
-      this->cached_vs_drive_alarm2_alt_raw_ = *val_a2;
-      this->publish_text_if_changed(this->vs_drive_alarm_alt_sensor_, this->cached_vs_drive_alarm_alt_,
+        (*val_a1 != this->cached_compressor_alarm1_alt_raw_ || *val_a2 != this->cached_compressor_alarm2_alt_raw_)) {
+      this->cached_compressor_alarm1_alt_raw_ = *val_a1;
+      this->cached_compressor_alarm2_alt_raw_ = *val_a2;
+      this->publish_text_if_changed(this->compressor_alarm_alt_sensor_, this->cached_compressor_alarm_alt_,
                                       get_vs_alarm_string(*val_a1, *val_a2));
     }
   }
@@ -1700,8 +1700,8 @@ void WaterFurnaceAurora::publish_vs_drive_sensors_(const RegisterMap &regs) {
 
 void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
   // FP1/FP2
-  this->publish_sensor_signed_tenths(regs, registers::FP1_TEMP, this->fp1_temperature_sensor_);
-  this->publish_sensor_signed_tenths(regs, registers::FP2_TEMP, this->fp2_temperature_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::FP1_TEMP, this->cooling_liquid_line_temperature_sensor_);
+  this->publish_sensor_signed_tenths(regs, registers::FP2_TEMP, this->air_coil_temperature_sensor_);
   
   // Line voltage setting and anti-short-cycle
   this->publish_sensor(regs, registers::LINE_VOLTAGE_SETTING, this->line_voltage_setting_sensor_);
@@ -1729,11 +1729,11 @@ void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
     this->publish_sensor(regs, registers::ECM_SPEED, this->blower_speed_sensor_);
   }
   this->publish_sensor(regs, registers::BLOWER_ONLY_SPEED, this->blower_only_speed_sensor_);
-  this->publish_sensor(regs, registers::LO_COMPRESSOR_ECM_SPEED, this->lo_compressor_speed_sensor_);
-  this->publish_sensor(regs, registers::HI_COMPRESSOR_ECM_SPEED, this->hi_compressor_speed_sensor_);
+  this->publish_sensor(regs, registers::LO_COMPRESSOR_ECM_SPEED, this->low_compressor_speed_sensor_);
+  this->publish_sensor(regs, registers::HI_COMPRESSOR_ECM_SPEED, this->high_compressor_speed_sensor_);
   this->publish_sensor(regs, registers::AUX_HEAT_ECM_SPEED, this->aux_heat_speed_sensor_);
   
-  // VS Pump
+  // Pump
   this->publish_sensor(regs, registers::VS_PUMP_SPEED, this->pump_speed_sensor_);
   this->publish_sensor(regs, registers::VS_PUMP_MIN, this->pump_min_speed_sensor_);
   this->publish_sensor(regs, registers::VS_PUMP_MAX, this->pump_max_speed_sensor_);
@@ -1782,12 +1782,12 @@ void WaterFurnaceAurora::publish_equipment_sensors_(const RegisterMap &regs) {
     }
   }
 
-  // VS Drive EEV2 Ctl (gap 15) — same bitmask as register 280
+  // Compressor drive EEV2 Ctl (gap 15) — same bitmask as register 280
   {
     const uint16_t *val = reg_find(regs, registers::VS_DRIVE_EEV2_CTL);
-    if (val && *val != this->cached_vs_drive_eev2_ctl_raw_) {
-      this->cached_vs_drive_eev2_ctl_raw_ = *val;
-      this->publish_text_if_changed(this->vs_drive_eev2_ctl_sensor_, this->cached_vs_drive_eev2_ctl_,
+    if (val && *val != this->cached_compressor_eev2_ctl_raw_) {
+      this->cached_compressor_eev2_ctl_raw_ = *val;
+      this->publish_text_if_changed(this->compressor_eev2_ctl_sensor_, this->cached_compressor_eev2_ctl_,
                                       get_eev2_ctl_string(*val));
     }
   }

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -121,31 +121,31 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void set_suction_pressure_sensor(sensor::Sensor *sensor) { this->suction_pressure_sensor_ = sensor; }
   void set_eev_open_percentage_sensor(sensor::Sensor *sensor) { this->eev_open_percentage_sensor_ = sensor; }
   void set_superheat_temperature_sensor(sensor::Sensor *sensor) { this->superheat_temperature_sensor_ = sensor; }
-  void set_fp1_temperature_sensor(sensor::Sensor *sensor) { this->fp1_temperature_sensor_ = sensor; }
-  void set_fp2_temperature_sensor(sensor::Sensor *sensor) { this->fp2_temperature_sensor_ = sensor; }
+  void set_cooling_liquid_line_temperature_sensor(sensor::Sensor *sensor) { this->cooling_liquid_line_temperature_sensor_ = sensor; }
+  void set_air_coil_temperature_sensor(sensor::Sensor *sensor) { this->air_coil_temperature_sensor_ = sensor; }
   void set_line_voltage_setting_sensor(sensor::Sensor *sensor) { this->line_voltage_setting_sensor_ = sensor; }
   void set_anti_short_cycle_sensor(sensor::Sensor *sensor) { this->anti_short_cycle_sensor_ = sensor; }
   
-  // Additional VS Drive sensors
+  // Additional compressor drive sensors
   void set_compressor_desired_speed_sensor(sensor::Sensor *sensor) { this->compressor_desired_speed_sensor_ = sensor; }
   void set_discharge_temperature_sensor(sensor::Sensor *sensor) { this->discharge_temperature_sensor_ = sensor; }
   void set_suction_temperature_sensor(sensor::Sensor *sensor) { this->suction_temperature_sensor_ = sensor; }
-  void set_vs_drive_temperature_sensor(sensor::Sensor *sensor) { this->vs_drive_temperature_sensor_ = sensor; }
-  void set_vs_inverter_temperature_sensor(sensor::Sensor *sensor) { this->vs_inverter_temperature_sensor_ = sensor; }
+  void set_compressor_drive_temperature_sensor(sensor::Sensor *sensor) { this->compressor_drive_temperature_sensor_ = sensor; }
+  void set_compressor_inverter_temperature_sensor(sensor::Sensor *sensor) { this->compressor_inverter_temperature_sensor_ = sensor; }
   
-  // Additional VS Drive sensors
-  void set_vs_fan_speed_sensor(sensor::Sensor *sensor) { this->vs_fan_speed_sensor_ = sensor; }
-  void set_vs_ambient_temperature_sensor(sensor::Sensor *sensor) { this->vs_ambient_temperature_sensor_ = sensor; }
-  void set_vs_compressor_watts_sensor(sensor::Sensor *sensor) { this->vs_compressor_watts_sensor_ = sensor; }
+  // Additional compressor drive sensors
+  void set_compressor_fan_speed_sensor(sensor::Sensor *sensor) { this->compressor_fan_speed_sensor_ = sensor; }
+  void set_compressor_ambient_temperature_sensor(sensor::Sensor *sensor) { this->compressor_ambient_temperature_sensor_ = sensor; }
+  void set_compressor_drive_watts_sensor(sensor::Sensor *sensor) { this->compressor_drive_watts_sensor_ = sensor; }
   void set_saturated_evaporator_discharge_temperature_sensor(sensor::Sensor *sensor) { this->saturated_evaporator_discharge_temperature_sensor_ = sensor; }
   void set_aux_heat_stage_sensor(sensor::Sensor *sensor) { this->aux_heat_stage_sensor_ = sensor; }
   
-  // VS Drive additional diagnostics
-  void set_vs_entering_water_temperature_sensor(sensor::Sensor *sensor) { this->vs_entering_water_temperature_sensor_ = sensor; }
-  void set_vs_line_voltage_sensor(sensor::Sensor *sensor) { this->vs_line_voltage_sensor_ = sensor; }
-  void set_vs_thermo_power_sensor(sensor::Sensor *sensor) { this->vs_thermo_power_sensor_ = sensor; }
-  void set_vs_supply_voltage_sensor(sensor::Sensor *sensor) { this->vs_supply_voltage_sensor_ = sensor; }
-  void set_vs_udc_voltage_sensor(sensor::Sensor *sensor) { this->vs_udc_voltage_sensor_ = sensor; }
+  // Compressor drive additional diagnostics
+  void set_compressor_entering_water_temperature_sensor(sensor::Sensor *sensor) { this->compressor_entering_water_temperature_sensor_ = sensor; }
+  void set_compressor_line_voltage_sensor(sensor::Sensor *sensor) { this->compressor_line_voltage_sensor_ = sensor; }
+  void set_compressor_thermo_power_sensor(sensor::Sensor *sensor) { this->compressor_thermo_power_sensor_ = sensor; }
+  void set_compressor_supply_voltage_sensor(sensor::Sensor *sensor) { this->compressor_supply_voltage_sensor_ = sensor; }
+  void set_compressor_udc_voltage_sensor(sensor::Sensor *sensor) { this->compressor_udc_voltage_sensor_ = sensor; }
   
   // AXB current sensors
   void set_blower_amps_sensor(sensor::Sensor *sensor) { this->blower_amps_sensor_ = sensor; }
@@ -167,11 +167,11 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   // Blower/ECM sensors
   void set_blower_speed_sensor(sensor::Sensor *sensor) { this->blower_speed_sensor_ = sensor; }
   void set_blower_only_speed_sensor(sensor::Sensor *sensor) { this->blower_only_speed_sensor_ = sensor; }
-  void set_lo_compressor_speed_sensor(sensor::Sensor *sensor) { this->lo_compressor_speed_sensor_ = sensor; }
-  void set_hi_compressor_speed_sensor(sensor::Sensor *sensor) { this->hi_compressor_speed_sensor_ = sensor; }
+  void set_low_compressor_speed_sensor(sensor::Sensor *sensor) { this->low_compressor_speed_sensor_ = sensor; }
+  void set_high_compressor_speed_sensor(sensor::Sensor *sensor) { this->high_compressor_speed_sensor_ = sensor; }
   void set_aux_heat_speed_sensor(sensor::Sensor *sensor) { this->aux_heat_speed_sensor_ = sensor; }
   
-  // VS Pump sensors
+  // Pump sensors
   void set_pump_speed_sensor(sensor::Sensor *sensor) { this->pump_speed_sensor_ = sensor; }
   void set_pump_min_speed_sensor(sensor::Sensor *sensor) { this->pump_min_speed_sensor_ = sensor; }
   void set_pump_max_speed_sensor(sensor::Sensor *sensor) { this->pump_max_speed_sensor_ = sensor; }
@@ -214,13 +214,13 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   // Condensate sensor (gap 13)
   void set_condensate_sensor(sensor::Sensor *sensor) { this->condensate_sensor_ = sensor; }
 
-  // VS Drive 3200-range duplicates (gap 14)
-  void set_vs_drive_derate_alt_sensor(text_sensor::TextSensor *sensor) { this->vs_drive_derate_alt_sensor_ = sensor; }
-  void set_vs_drive_safe_mode_alt_sensor(text_sensor::TextSensor *sensor) { this->vs_drive_safe_mode_alt_sensor_ = sensor; }
-  void set_vs_drive_alarm_alt_sensor(text_sensor::TextSensor *sensor) { this->vs_drive_alarm_alt_sensor_ = sensor; }
+  // Compressor drive 3200-range alt diagnostics (gap 14)
+  void set_compressor_derate_alt_sensor(text_sensor::TextSensor *sensor) { this->compressor_derate_alt_sensor_ = sensor; }
+  void set_compressor_safe_mode_alt_sensor(text_sensor::TextSensor *sensor) { this->compressor_safe_mode_alt_sensor_ = sensor; }
+  void set_compressor_alarm_alt_sensor(text_sensor::TextSensor *sensor) { this->compressor_alarm_alt_sensor_ = sensor; }
 
-  // VS Drive EEV2 Ctl (gap 15)
-  void set_vs_drive_eev2_ctl_sensor(text_sensor::TextSensor *sensor) { this->vs_drive_eev2_ctl_sensor_ = sensor; }
+  // Compressor drive EEV2 Ctl (gap 15)
+  void set_compressor_eev2_ctl_sensor(text_sensor::TextSensor *sensor) { this->compressor_eev2_ctl_sensor_ = sensor; }
 
   // Dealer information (gap 19)
   void set_dealer_name_sensor(text_sensor::TextSensor *sensor) { this->dealer_name_sensor_ = sensor; }
@@ -239,7 +239,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void set_blower_running_binary_sensor(binary_sensor::BinarySensor *sensor) { this->blower_running_sensor_ = sensor; }
   void set_aux_heat_running_binary_sensor(binary_sensor::BinarySensor *sensor) { this->aux_heat_running_sensor_ = sensor; }
   void set_dhw_running_binary_sensor(binary_sensor::BinarySensor *sensor) { this->dhw_running_sensor_ = sensor; }
-  void set_lockout_binary_sensor(binary_sensor::BinarySensor *sensor) { this->lockout_sensor_ = sensor; }
+  void set_locked_out_binary_sensor(binary_sensor::BinarySensor *sensor) { this->locked_out_sensor_ = sensor; }
   void set_loop_pump_running_binary_sensor(binary_sensor::BinarySensor *sensor) { this->loop_pump_running_sensor_ = sensor; }
   void set_humidifier_running_binary_sensor(binary_sensor::BinarySensor *sensor) { this->humidifier_running_sensor_ = sensor; }
   void set_dehumidifier_running_binary_sensor(binary_sensor::BinarySensor *sensor) { this->dehumidifier_running_sensor_ = sensor; }
@@ -268,9 +268,9 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void set_model_number_sensor(text_sensor::TextSensor *sensor) { this->model_number_sensor_ = sensor; }
   void set_serial_number_sensor(text_sensor::TextSensor *sensor) { this->serial_number_sensor_ = sensor; }
   void set_fault_history_sensor(text_sensor::TextSensor *sensor) { this->fault_history_sensor_ = sensor; }
-  void set_vs_derate_sensor(text_sensor::TextSensor *sensor) { this->vs_derate_sensor_ = sensor; }
-  void set_vs_safe_mode_sensor(text_sensor::TextSensor *sensor) { this->vs_safe_mode_sensor_ = sensor; }
-  void set_vs_alarm_sensor(text_sensor::TextSensor *sensor) { this->vs_alarm_sensor_ = sensor; }
+  void set_compressor_derate_sensor(text_sensor::TextSensor *sensor) { this->compressor_derate_sensor_ = sensor; }
+  void set_compressor_safe_mode_sensor(text_sensor::TextSensor *sensor) { this->compressor_safe_mode_sensor_ = sensor; }
+  void set_compressor_alarm_sensor(text_sensor::TextSensor *sensor) { this->compressor_alarm_sensor_ = sensor; }
   void set_axb_inputs_sensor(text_sensor::TextSensor *sensor) { this->axb_inputs_sensor_ = sensor; }
   void set_humidifier_mode_sensor(text_sensor::TextSensor *sensor) { this->humidifier_mode_sensor_ = sensor; }
   void set_dehumidifier_mode_sensor(text_sensor::TextSensor *sensor) { this->dehumidifier_mode_sensor_ = sensor; }
@@ -478,7 +478,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void publish_temperature_sensors_(const RegisterMap &regs);
   void publish_mode_sensors_(const RegisterMap &regs);
   void publish_power_loop_sensors_(const RegisterMap &regs);
-  void publish_vs_drive_sensors_(const RegisterMap &regs);
+  void publish_compressor_drive_sensors_(const RegisterMap &regs);
   void publish_equipment_sensors_(const RegisterMap &regs);
   void publish_config_sensors_(const RegisterMap &regs);
   void publish_humidity_control_sensors_(const RegisterMap &regs);
@@ -767,8 +767,8 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   sensor::Sensor *suction_pressure_sensor_{nullptr};
   sensor::Sensor *eev_open_percentage_sensor_{nullptr};
   sensor::Sensor *superheat_temperature_sensor_{nullptr};
-  sensor::Sensor *fp1_temperature_sensor_{nullptr};
-  sensor::Sensor *fp2_temperature_sensor_{nullptr};
+  sensor::Sensor *cooling_liquid_line_temperature_sensor_{nullptr};
+  sensor::Sensor *air_coil_temperature_sensor_{nullptr};
   sensor::Sensor *heating_liquid_line_temperature_sensor_{nullptr};
   sensor::Sensor *saturated_condenser_temperature_sensor_{nullptr};
   sensor::Sensor *subcool_temperature_sensor_{nullptr};
@@ -798,28 +798,28 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   sensor::Sensor *eev_suction_temperature_sensor_{nullptr};
   sensor::Sensor *eev_saturated_suction_temperature_sensor_{nullptr};
 
-  // --- VS Drive sensors ---
+  // --- Compressor drive sensors ---
   sensor::Sensor *compressor_desired_speed_sensor_{nullptr};
   sensor::Sensor *discharge_temperature_sensor_{nullptr};
   sensor::Sensor *suction_temperature_sensor_{nullptr};
-  sensor::Sensor *vs_drive_temperature_sensor_{nullptr};
-  sensor::Sensor *vs_inverter_temperature_sensor_{nullptr};
-  sensor::Sensor *vs_fan_speed_sensor_{nullptr};
-  sensor::Sensor *vs_ambient_temperature_sensor_{nullptr};
-  sensor::Sensor *vs_compressor_watts_sensor_{nullptr};
+  sensor::Sensor *compressor_drive_temperature_sensor_{nullptr};
+  sensor::Sensor *compressor_inverter_temperature_sensor_{nullptr};
+  sensor::Sensor *compressor_fan_speed_sensor_{nullptr};
+  sensor::Sensor *compressor_ambient_temperature_sensor_{nullptr};
+  sensor::Sensor *compressor_drive_watts_sensor_{nullptr};
   sensor::Sensor *saturated_evaporator_discharge_temperature_sensor_{nullptr};
-  sensor::Sensor *vs_entering_water_temperature_sensor_{nullptr};
-  sensor::Sensor *vs_line_voltage_sensor_{nullptr};
-  sensor::Sensor *vs_thermo_power_sensor_{nullptr};
-  sensor::Sensor *vs_supply_voltage_sensor_{nullptr};
-  sensor::Sensor *vs_udc_voltage_sensor_{nullptr};
+  sensor::Sensor *compressor_entering_water_temperature_sensor_{nullptr};
+  sensor::Sensor *compressor_line_voltage_sensor_{nullptr};
+  sensor::Sensor *compressor_thermo_power_sensor_{nullptr};
+  sensor::Sensor *compressor_supply_voltage_sensor_{nullptr};
+  sensor::Sensor *compressor_udc_voltage_sensor_{nullptr};
 
   // --- ECM / blower speed sensors ---
   sensor::Sensor *aux_heat_stage_sensor_{nullptr};
   sensor::Sensor *blower_speed_sensor_{nullptr};
   sensor::Sensor *blower_only_speed_sensor_{nullptr};
-  sensor::Sensor *lo_compressor_speed_sensor_{nullptr};
-  sensor::Sensor *hi_compressor_speed_sensor_{nullptr};
+  sensor::Sensor *low_compressor_speed_sensor_{nullptr};
+  sensor::Sensor *high_compressor_speed_sensor_{nullptr};
   sensor::Sensor *aux_heat_speed_sensor_{nullptr};
 
   // --- Pump sensors ---
@@ -862,7 +862,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   binary_sensor::BinarySensor *compressor_running_sensor_{nullptr};
   binary_sensor::BinarySensor *blower_running_sensor_{nullptr};
   binary_sensor::BinarySensor *aux_heat_running_sensor_{nullptr};
-  binary_sensor::BinarySensor *lockout_sensor_{nullptr};
+  binary_sensor::BinarySensor *locked_out_sensor_{nullptr};
   binary_sensor::BinarySensor *emergency_shutdown_sensor_{nullptr};
   binary_sensor::BinarySensor *load_shed_sensor_{nullptr};
   binary_sensor::BinarySensor *fan_call_sensor_{nullptr};
@@ -897,9 +897,9 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   text_sensor::TextSensor *model_number_sensor_{nullptr};
   text_sensor::TextSensor *serial_number_sensor_{nullptr};
   text_sensor::TextSensor *fault_history_sensor_{nullptr};
-  text_sensor::TextSensor *vs_derate_sensor_{nullptr};
-  text_sensor::TextSensor *vs_safe_mode_sensor_{nullptr};
-  text_sensor::TextSensor *vs_alarm_sensor_{nullptr};
+  text_sensor::TextSensor *compressor_derate_sensor_{nullptr};
+  text_sensor::TextSensor *compressor_safe_mode_sensor_{nullptr};
+  text_sensor::TextSensor *compressor_alarm_sensor_{nullptr};
   text_sensor::TextSensor *axb_inputs_sensor_{nullptr};
   text_sensor::TextSensor *humidifier_mode_sensor_{nullptr};
   text_sensor::TextSensor *dehumidifier_mode_sensor_{nullptr};
@@ -914,13 +914,13 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   text_sensor::TextSensor *ha_alarm_2_action_sensor_{nullptr};
   text_sensor::TextSensor *energy_phase_type_sensor_{nullptr};
 
-  // --- VS Drive 3200-range duplicates (gap 14) ---
-  text_sensor::TextSensor *vs_drive_derate_alt_sensor_{nullptr};
-  text_sensor::TextSensor *vs_drive_safe_mode_alt_sensor_{nullptr};
-  text_sensor::TextSensor *vs_drive_alarm_alt_sensor_{nullptr};
+  // --- Compressor drive 3200-range alt diagnostics (gap 14) ---
+  text_sensor::TextSensor *compressor_derate_alt_sensor_{nullptr};
+  text_sensor::TextSensor *compressor_safe_mode_alt_sensor_{nullptr};
+  text_sensor::TextSensor *compressor_alarm_alt_sensor_{nullptr};
 
-  // --- VS Drive EEV2 Ctl (gap 15) ---
-  text_sensor::TextSensor *vs_drive_eev2_ctl_sensor_{nullptr};
+  // --- Compressor drive EEV2 Ctl (gap 15) ---
+  text_sensor::TextSensor *compressor_eev2_ctl_sensor_{nullptr};
 
   // --- Dealer information (gap 19) ---
   text_sensor::TextSensor *dealer_name_sensor_{nullptr};
@@ -949,13 +949,13 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   std::string cached_fault_description_;
   std::string cached_hvac_mode_;
   std::string cached_fan_mode_;
-  std::string cached_vs_derate_;
-  uint16_t cached_vs_derate_raw_{0xFFFF};
-  std::string cached_vs_safe_mode_;
-  uint16_t cached_vs_safe_mode_raw_{0xFFFF};
-  std::string cached_vs_alarm_;
-  uint16_t cached_vs_alarm1_raw_{0xFFFF};
-  uint16_t cached_vs_alarm2_raw_{0xFFFF};
+  std::string cached_compressor_derate_;
+  uint16_t cached_compressor_derate_raw_{0xFFFF};
+  std::string cached_compressor_safe_mode_;
+  uint16_t cached_compressor_safe_mode_raw_{0xFFFF};
+  std::string cached_compressor_alarm_;
+  uint16_t cached_compressor_alarm1_raw_{0xFFFF};
+  uint16_t cached_compressor_alarm2_raw_{0xFFFF};
   std::string cached_axb_inputs_;
   uint16_t cached_axb_inputs_raw_{0xFFFF};
   std::string cached_humidifier_mode_;
@@ -969,17 +969,17 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   std::string cached_ha_alarm_1_action_;
   std::string cached_ha_alarm_2_action_;
   std::string cached_energy_phase_type_;
-  // VS Drive alt text sensor caches (gap 14)
-  std::string cached_vs_drive_derate_alt_;
-  uint16_t cached_vs_drive_derate_alt_raw_{0xFFFF};
-  std::string cached_vs_drive_safe_mode_alt_;
-  uint16_t cached_vs_drive_safe_mode_alt_raw_{0xFFFF};
-  std::string cached_vs_drive_alarm_alt_;
-  uint16_t cached_vs_drive_alarm1_alt_raw_{0xFFFF};
-  uint16_t cached_vs_drive_alarm2_alt_raw_{0xFFFF};
-  // VS Drive EEV2 Ctl cache (gap 15)
-  std::string cached_vs_drive_eev2_ctl_;
-  uint16_t cached_vs_drive_eev2_ctl_raw_{0xFFFF};
+  // Compressor drive alt text sensor caches (gap 14)
+  std::string cached_compressor_derate_alt_;
+  uint16_t cached_compressor_derate_alt_raw_{0xFFFF};
+  std::string cached_compressor_safe_mode_alt_;
+  uint16_t cached_compressor_safe_mode_alt_raw_{0xFFFF};
+  std::string cached_compressor_alarm_alt_;
+  uint16_t cached_compressor_alarm1_alt_raw_{0xFFFF};
+  uint16_t cached_compressor_alarm2_alt_raw_{0xFFFF};
+  // Compressor drive EEV2 Ctl cache (gap 15)
+  std::string cached_compressor_eev2_ctl_;
+  uint16_t cached_compressor_eev2_ctl_raw_{0xFFFF};
   // Dealer info caches (gap 19)
   std::string cached_dealer_name_;
   std::string cached_dealer_phone_;

--- a/local_dev.yaml
+++ b/local_dev.yaml
@@ -164,9 +164,9 @@ number:
     # NOTE: Requires ECM blower (blower type 1 or 2). Shows "Unknown" on PSC/5-speed blowers.
     blower_only_speed:
       name: "Indoor Blower Only Speed"
-    lo_compressor_speed:
+    low_compressor_speed:
       name: "Low Compressor ECM Speed"
-    hi_compressor_speed:
+    high_compressor_speed:
       name: "High Compressor ECM Speed"
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed"
@@ -259,25 +259,25 @@ sensor:
       name: "Heating Liquid Line Temperature"
     saturated_condenser_temperature:
       name: "Saturated Condenser Temperature"
-    fp1_temperature:
+    cooling_liquid_line_temperature:
       name: "FP1 Temperature"
-    fp2_temperature:
+    air_coil_temperature:
       name: "FP2 Temperature"
     
     # VS Drive temperatures (requires VS drive; shows "Unknown" on non-VS systems)
-    vs_drive_temperature:
+    compressor_drive_temperature:
       name: "VS Drive Temperature"
-    vs_inverter_temperature:
+    compressor_inverter_temperature:
       name: "VS Inverter Temperature"
-    vs_ambient_temperature:
+    compressor_ambient_temperature:
       name: "VS Compressor Ambient Temperature"
     saturated_evaporator_discharge_temperature:
       name: "Saturated Evaporator Discharge Temperature"
     
     # VS Drive additional (requires VS drive)
-    vs_fan_speed:
+    compressor_fan_speed:
       name: "VS Fan Speed"
-    vs_compressor_watts:
+    compressor_drive_watts:
       name: "VS Compressor Power"
     
     # Aux electric heat
@@ -313,9 +313,9 @@ sensor:
       name: "Indoor Blower Speed"
     blower_only_speed:
       name: "Indoor Blower Only Speed Setting"
-    lo_compressor_speed:
+    low_compressor_speed:
       name: "Low Compressor ECM Speed Setting"
-    hi_compressor_speed:
+    high_compressor_speed:
       name: "High Compressor ECM Speed Setting"
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed Setting"
@@ -394,7 +394,7 @@ binary_sensor:
       name: "Dehumidifier Running"
     
     # Fault/problem states
-    lockout:
+    locked_out:
       name: "Lockout"
       device_class: problem
     low_pressure_switch:
@@ -442,11 +442,11 @@ text_sensor:
       name: "Serial Number"
     
     # VS Drive status (requires VS drive; show "Unknown" on non-VS systems)
-    vs_derate:
+    compressor_derate:
       name: "VS Drive Derate"
-    vs_safe_mode:
+    compressor_safe_mode:
       name: "VS Drive Safe Mode"
-    vs_alarm:
+    compressor_alarm:
       name: "VS Drive Alarm"
     
     # AXB status

--- a/tests/waterfurnace-test.yaml
+++ b/tests/waterfurnace-test.yaml
@@ -97,9 +97,9 @@ number:
       name: "Test DHW Setpoint"
     blower_only_speed:
       name: "Test Indoor Blower Only Speed"
-    lo_compressor_speed:
+    low_compressor_speed:
       name: "Test Lo Compressor Speed"
-    hi_compressor_speed:
+    high_compressor_speed:
       name: "Test Hi Compressor Speed"
     aux_heat_speed:
       name: "Test Aux Electric Heat Speed"
@@ -176,9 +176,9 @@ sensor:
       name: "Test Fault Code"
     lockout_fault_code:
       name: "Test Lockout Fault Code"
-    fp1_temperature:
+    cooling_liquid_line_temperature:
       name: "Test FP1 Temp"
-    fp2_temperature:
+    air_coil_temperature:
       name: "Test FP2 Temp"
     line_voltage_setting:
       name: "Test Line Voltage Setting"
@@ -190,17 +190,17 @@ sensor:
       name: "Test Discharge Temp"
     suction_temperature:
       name: "Test Suction Temp"
-    vs_drive_temperature:
+    compressor_drive_temperature:
       name: "Test VS Drive Temp"
-    vs_inverter_temperature:
+    compressor_inverter_temperature:
       name: "Test VS Inverter Temp"
     blower_speed:
       name: "Test Indoor Blower Speed"
     blower_only_speed:
       name: "Test Indoor Blower Only Speed Sensor"
-    lo_compressor_speed:
+    low_compressor_speed:
       name: "Test Lo Compressor Speed Sensor"
-    hi_compressor_speed:
+    high_compressor_speed:
       name: "Test Hi Compressor Speed Sensor"
     aux_heat_speed:
       name: "Test Aux Electric Heat Speed Sensor"
@@ -220,11 +220,11 @@ sensor:
       name: "Test Heat of Extraction"
     heat_of_rejection:
       name: "Test Heat of Rejection"
-    vs_fan_speed:
+    compressor_fan_speed:
       name: "Test VS Fan Speed"
-    vs_ambient_temperature:
+    compressor_ambient_temperature:
       name: "Test VS Ambient Temp"
-    vs_compressor_watts:
+    compressor_drive_watts:
       name: "Test VS Compressor Watts"
     saturated_evaporator_discharge_temperature:
       name: "Test Sat Evap Discharge Temp"
@@ -244,15 +244,15 @@ sensor:
       name: "Test Water Delta-T"
     approach_temperature:
       name: "Test Approach Temp"
-    vs_entering_water_temperature:
+    compressor_entering_water_temperature:
       name: "Test VS Entering Water Temp"
-    vs_line_voltage:
+    compressor_line_voltage:
       name: "Test VS Line Voltage"
-    vs_thermo_power:
+    compressor_thermo_power:
       name: "Test VS Thermo Power"
-    vs_supply_voltage:
+    compressor_supply_voltage:
       name: "Test VS Supply Voltage"
-    vs_udc_voltage:
+    compressor_udc_voltage:
       name: "Test VS UDC Voltage"
     blower_amps:
       name: "Test Blower Amps"
@@ -311,7 +311,7 @@ binary_sensor:
       name: "Test DHW Running"
     loop_pump_running:
       name: "Test Loop Pump Running"
-    lockout:
+    locked_out:
       name: "Test Lockout"
     humidifier_running:
       name: "Test Humidifier Running"
@@ -359,11 +359,11 @@ text_sensor:
       name: "Test Serial Number"
     fault_history:
       name: "Test Fault History"
-    vs_derate:
+    compressor_derate:
       name: "Test VS Derate"
-    vs_safe_mode:
+    compressor_safe_mode:
       name: "Test VS Safe Mode"
-    vs_alarm:
+    compressor_alarm:
       name: "Test VS Alarm"
     axb_inputs:
       name: "Test AXB Inputs"
@@ -395,14 +395,14 @@ text_sensor:
     energy_phase_type:
       name: "Test Energy Phase Type"
     # VS Drive 3200-range duplicates (gap 14)
-    vs_drive_derate_alt:
+    compressor_derate_alt:
       name: "Test VS Drive Derate Alt"
-    vs_drive_safe_mode_alt:
+    compressor_safe_mode_alt:
       name: "Test VS Drive Safe Mode Alt"
-    vs_drive_alarm_alt:
+    compressor_alarm_alt:
       name: "Test VS Drive Alarm Alt"
     # VS Drive EEV2 Ctl (gap 15)
-    vs_drive_eev2_ctl:
+    compressor_eev2_ctl:
       name: "Test VS Drive EEV2 Ctl"
     # Dealer information (gap 19)
     dealer_name:

--- a/waterfurnace_aurora.yaml
+++ b/waterfurnace_aurora.yaml
@@ -150,9 +150,9 @@ number:
     # NOTE: Requires ECM blower (blower type 1 or 2). Shows "Unknown" on PSC/5-speed blowers.
     blower_only_speed:
       name: "Indoor Blower Only Speed"
-    lo_compressor_speed:
+    low_compressor_speed:
       name: "Low Compressor ECM Speed"
-    hi_compressor_speed:
+    high_compressor_speed:
       name: "High Compressor ECM Speed"
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed"
@@ -245,25 +245,25 @@ sensor:
       name: "Heating Liquid Line Temperature"
     saturated_condenser_temperature:
       name: "Saturated Condenser Temperature"
-    fp1_temperature:
+    cooling_liquid_line_temperature:
       name: "FP1 Temperature"
-    fp2_temperature:
+    air_coil_temperature:
       name: "FP2 Temperature"
     
     # VS Drive temperatures (requires VS drive; shows "Unknown" on non-VS systems)
-    vs_drive_temperature:
+    compressor_drive_temperature:
       name: "VS Drive Temperature"
-    vs_inverter_temperature:
+    compressor_inverter_temperature:
       name: "VS Inverter Temperature"
-    vs_ambient_temperature:
+    compressor_ambient_temperature:
       name: "VS Compressor Ambient Temperature"
     saturated_evaporator_discharge_temperature:
       name: "Saturated Evaporator Discharge Temperature"
     
     # VS Drive additional (requires VS drive)
-    vs_fan_speed:
+    compressor_fan_speed:
       name: "VS Fan Speed"
-    vs_compressor_watts:
+    compressor_drive_watts:
       name: "VS Compressor Power"
     
     # Aux electric heat
@@ -299,9 +299,9 @@ sensor:
       name: "Indoor Blower Speed"
     blower_only_speed:
       name: "Indoor Blower Only Speed Setting"
-    lo_compressor_speed:
+    low_compressor_speed:
       name: "Low Compressor ECM Speed Setting"
-    hi_compressor_speed:
+    high_compressor_speed:
       name: "High Compressor ECM Speed Setting"
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed Setting"
@@ -365,7 +365,7 @@ binary_sensor:
       name: "Dehumidifier Running"
     
     # Fault/problem states
-    lockout:
+    locked_out:
       name: "Lockout"
       device_class: problem
     low_pressure_switch:
@@ -409,11 +409,11 @@ text_sensor:
       name: "Serial Number"
     
     # VS Drive status (requires VS drive; show "Unknown" on non-VS systems)
-    vs_derate:
+    compressor_derate:
       name: "VS Drive Derate"
-    vs_safe_mode:
+    compressor_safe_mode:
       name: "VS Drive Safe Mode"
-    vs_alarm:
+    compressor_alarm:
       name: "VS Drive Alarm"
     
     # AXB status


### PR DESCRIPTION
## Summary

Renames 22 user-facing YAML entity keys to align with the upstream [waterfurnace_aurora Ruby gem](https://github.com/ccutrer/waterfurnace_aurora) naming conventions. Closes #22.

**This is a breaking change.** Existing YAML configs using old keys will get a clear `unknown key` error at compile time. Home Assistant entity IDs derived from old names will also change — users should delete stale entities in HA after updating.

## Why now?

The component is pre-1.0 with a small user base. PR #20 just landed ~25 new sensors — better to rename now before those names become entrenched in user automations and dashboards. Hard rename with no deprecation aliases; the user base is small enough that a clean break beats permanent backward-compat baggage.

## What changed

Three categories of naming inconsistency addressed:

### 1. Cryptic abbreviations → descriptive names
Internal register names like `fp1_temperature` are meaningless without the service manual. The gem uses human-readable names.

### 2. `vs_` prefix → `compressor_` prefix
"VS" (Variable Speed) is an implementation detail about how the compressor is controlled. The gem groups these under a `compressor` Homie node. Since ESPHome has no node hierarchy, `compressor_*` is the natural translation.

### 3. `lo_`/`hi_` → `low_`/`high_`
Minor abbreviation expansion to match the gem.

## Migration table

```
Old Key                            → New Key
──────────────────────────────────────────────────────────────
Sensors (14 renames):
  fp1_temperature                  → cooling_liquid_line_temperature
  fp2_temperature                  → air_coil_temperature
  vs_drive_temperature             → compressor_drive_temperature
  vs_inverter_temperature          → compressor_inverter_temperature
  vs_ambient_temperature           → compressor_ambient_temperature
  vs_fan_speed                     → compressor_fan_speed
  vs_compressor_watts              → compressor_drive_watts
  vs_line_voltage                  → compressor_line_voltage
  vs_supply_voltage                → compressor_supply_voltage
  vs_udc_voltage                   → compressor_udc_voltage
  vs_thermo_power                  → compressor_thermo_power
  vs_entering_water_temperature    → compressor_entering_water_temperature
  lo_compressor_speed              → low_compressor_speed
  hi_compressor_speed              → high_compressor_speed

Text Sensors (7 renames):
  vs_derate                        → compressor_derate
  vs_safe_mode                     → compressor_safe_mode
  vs_alarm                         → compressor_alarm
  vs_drive_derate_alt              → compressor_derate_alt
  vs_drive_safe_mode_alt           → compressor_safe_mode_alt
  vs_drive_alarm_alt               → compressor_alarm_alt
  vs_drive_eev2_ctl                → compressor_eev2_ctl

Binary Sensors (1 rename):
  lockout                          → locked_out

Numbers (2 renames):
  lo_compressor_speed              → low_compressor_speed
  hi_compressor_speed              → high_compressor_speed
```

## `compressor_watts` collision — design decision

Two distinct compressor power measurements exist:
- `compressor_watts` — AXB energy monitor (current × voltage), existed first, more users have it
- `vs_compressor_watts` → **`compressor_drive_watts`** — VS drive controller direct reading (reg 3422)

We keep `compressor_watts` for the AXB version and rename the VS version to `compressor_drive_watts` to distinguish them.

## What's NOT renamed

- **Register constants** (`FP1_TEMP`, `VS_DRIVE_TEMP`, etc.) — internal-only, standard WaterFurnace terminology. Comments added to `FP1_TEMP`/`FP2_TEMP` for clarity.
- **Hardware detection flags** (`has_vs_drive_`, `vs_drive_override_`) — describe hardware capability, not user-facing entities.
- **Internal helper functions** (`get_vs_derate_string()`, etc.) — decode register bitmasks, not entity names.
- **Entities already aligned** — `entering_air_temperature`, `compressor_speed`, all DHW/pump/zone entities, etc.

## Files changed (10 files, 213+/213-)

| File | Changes |
|------|---------|
| `sensor/__init__.py` | 14 key renames in SENSORS dict |
| `text_sensor/__init__.py` | 7 key renames in TEXT_SENSORS dict |
| `binary_sensor/__init__.py` | 1 key rename in BINARY_SENSORS dict |
| `number/__init__.py` | 2 key renames + CONF constants |
| `waterfurnace_aurora.h` | Setter methods, member variables, cached values, method rename |
| `waterfurnace_aurora.cpp` | All member references (53 lines), method `publish_vs_drive_sensors_` → `publish_compressor_drive_sensors_` |
| `registers.h` | Comments added to FP1_TEMP/FP2_TEMP |
| `tests/waterfurnace-test.yaml` | All 24 key renames |
| `local_dev.yaml` | All applicable key renames |
| `waterfurnace_aurora.yaml` | All applicable key renames |

## Verification

- Unit tests: **504 assertions across 59 test cases — all pass**
- ESPHome compile: **`tests/waterfurnace-test.yaml` builds successfully**
- Stale name grep: **zero old names remain** in source files (only register constants and hardware detection flags, as intended)
- Python↔C++ parity: **all 22 Python dict keys verified** against corresponding `set_{key}_sensor` methods, member variables, and `.cpp` usage