### PR TITLE
fix: migrate sensor .raw_state to get_raw_state() for ESPHome 2026.4.0

### DIFF
--- a/components/waterfurnace_aurora/climate/aurora_climate.cpp
+++ b/components/waterfurnace_aurora/climate/aurora_climate.cpp
@@ -435,7 +435,7 @@ void AuroraClimate::publish_zone_diagnostics_() {
   if (this->zone_normalized_size_sensor_ != nullptr) {
     float norm_size = static_cast<float>(zone.normalized_size);
     if (!this->zone_normalized_size_sensor_->has_state() ||
-        this->zone_normalized_size_sensor_->raw_state != norm_size) {
+        this->zone_normalized_size_sensor_->get_raw_state() != norm_size) {
       this->zone_normalized_size_sensor_->publish_state(norm_size);
     }
   }

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -537,9 +537,9 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
     if (sensor == nullptr) return false;
     if (!sensor->has_state()) return true;  // First publish — always send
     // Both NaN → no change; one NaN → changed; otherwise compare values
-    if (std::isnan(value)) return !std::isnan(sensor->raw_state);
-    if (std::isnan(sensor->raw_state)) return true;
-    return value != sensor->raw_state;
+    if (std::isnan(value)) return !std::isnan(sensor->get_raw_state());
+    if (std::isnan(sensor->get_raw_state())) return true;
+    return value != sensor->get_raw_state();
   }
 
   bool publish_sensor(const RegisterMap &result, uint16_t reg,

--- a/tests/mocks/esphome/components/sensor/sensor.h
+++ b/tests/mocks/esphome/components/sensor/sensor.h
@@ -15,6 +15,7 @@ class Sensor {
   }
 
   bool has_state() const { return this->has_state_; }
+  float get_raw_state() const { return this->raw_state; }
   
   float state{NAN};
   float raw_state{NAN};


### PR DESCRIPTION
## Summary

- Replace all 4 occurrences of deprecated `sensor->raw_state` direct access with `sensor->get_raw_state()`
- Update test mock to include the `get_raw_state()` accessor

Backward compatible — `get_raw_state()` has been available since early ESPHome versions.

Closes #23