### PR TITLE
fix errors in communications protocol that caused data reads to fail

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,7 +58,7 @@ This builds and runs three test binaries:
 
 ### Key Design Decisions
 
-- **Zero blocking I/O** — The state machine never blocks. Bytes are read incrementally in `loop()`. No `delay()` calls in the communication path.
+- **Mostly non-blocking I/O** — Response bytes are read incrementally in `loop()` with no `delay()`. The one intentional block is `flush()` during RS-485 transmit turnaround in `send_request_common_()` (same pattern as ESPHome's built-in `modbus` component): wait until TX has left the wire, then release DE/RE immediately so fast ABC replies are not truncated. Request frames are small, so this is typically a few–tens of ms at 19200 baud.
 - **Write cooldowns** — 10-second cooldown after writes prevents stale read-backs from reverting optimistic UI updates.
 - **Connected sensor** — Tracks RS-485 communication health with configurable timeout (default 30s).
 - **Flat sorted vector** — `RegisterMap` uses binary search on a sorted `vector<pair>` instead of `std::map`, saving ~4KB heap fragmentation on ESP32.

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -65,18 +65,54 @@ void WaterFurnaceAurora::send_request_common_(const uint8_t *frame, size_t frame
     this->flow_control_pin_->digital_write(true);
   }
   
-  // Send frame — write_array buffers into the UART TX FIFO.
-  // We intentionally do NOT call flush() here. The hardware UART transmits
-  // asynchronously from its FIFO. flush() would block for up to ~106ms on a
-  // 200-byte frame at 19200 baud, exceeding the 50ms WARN_IF_BLOCKING threshold.
-  // Instead, the RS-485 flow control pin is switched back to RX by a deferred
-  // timeout, allowing the main loop to remain non-blocking.
+  // Send frame and BLOCK until the UART hardware confirms it has actually left
+  // the wire (flush() -> uart_wait_tx_done() on the esp-idf UART backend).
+  //
+  // NOTE: this used to be non-blocking — write_array() would queue the bytes
+  // and the RS-485 direction pin would be switched back to RX after a
+  // hand-estimated delay (frame_bytes * 11 bits / baud). That estimate is only
+  // valid on backends where write() itself blocks until the data is on the
+  // wire (e.g. the Arduino HardwareSerial framework). On the esp-idf UART
+  // driver, write_array() just copies bytes into a ring buffer and returns
+  // almost immediately — actual transmission happens later, asynchronously,
+  // via interrupt. That mismatch meant the flow-control pin was frequently
+  // flipped to RX mode *before* our own request had finished transmitting,
+  // truncating the outgoing frame and injecting a glitch byte into the RX
+  // path right as the transceiver reversed direction — which desynced the
+  // response parser for the rest of that exchange (see CRC-mismatch/timeout
+  // pattern in the field logs). flush() is the only reliable way to know TX
+  // is actually done. For the frame sizes this component sends (well under
+  // ~150 bytes), that's at most ~90ms at 19200 baud — worth it for correct
+  // framing. If this ever needs to be non-blocking again, the fix has to be
+  // a real completion signal (e.g. polling the driver's TX-done state), not
+  // a bigger fixed delay — a race is still a race no matter the margin.
   this->write_array(frame, frame_len);
+  this->flush();
+  
+  // IMPORTANT: flip the RS-485 transceiver back to RX and start listening
+  // *synchronously*, right here — do NOT defer this to a future loop() tick
+  // (e.g. via a TX_PENDING state checked against a timestamp). flush() only
+  // guarantees TX is physically done; if we then wait for the *next* call
+  // to loop() to notice that and flip the pin, we introduce a second,
+  // scheduler-dependent gap during which the ESP is still deaf. On a build
+  // with WiFi, the API, web_server, and a couple dozen entities sharing the
+  // loop, that gap is easily long enough (tens of ms) to miss the first
+  // several bytes of a fast-turnaround slave's response — which is exactly
+  // what field logs showed even after making flush() synchronous: captures
+  // that were always a truncated, mid-frame window into the real response,
+  // never starting at the address/function header. Doing the pin flip here,
+  // in the same call stack as flush(), removes that gap entirely.
+  if (this->flow_control_pin_ != nullptr) {
+    this->flow_control_pin_->digital_write(false);
+  }
   
   this->pending_request_ = type;
   this->last_request_time_ = millis();
-  this->tx_complete_time_ = millis() + this->tx_time_ms_(frame_len);
-  this->transition_(State::TX_PENDING);
+  // Reference point for the response timeout in the WAITING_RESPONSE state.
+  // TX is already fully complete and we're already listening, so this is
+  // simply "now" — no estimate or margin needed anymore.
+  this->tx_complete_time_ = millis();
+  this->transition_(State::WAITING_RESPONSE);
 }
 
 void WaterFurnaceAurora::send_request_(const uint8_t *frame, size_t frame_len, PendingRequest type,
@@ -96,6 +132,22 @@ bool WaterFurnaceAurora::read_frame_() {
   // Drain available bytes into persistent rx_buffer_
   while (this->available() && this->rx_buffer_len_ < protocol::MAX_FRAME_SIZE) {
     this->rx_buffer_[this->rx_buffer_len_++] = this->read();
+  }
+  
+  // Resync guard: a real frame must start with our slave address. If a stray
+  // byte (line noise, a transceiver turnaround glitch, etc.) ever ends up at
+  // the front of rx_buffer_, expected_frame_size() below has no way to know
+  // that — it just trusts byte[0]/byte[1] as address/function and computes a
+  // frame length from whatever garbage is there, which then either never
+  // matches a real boundary (permanent desync until the next timeout) or,
+  // worse, coincidentally "completes" on a bogus length and reports a false
+  // CRC-mismatch frame while quietly discarding real response bytes. Instead,
+  // discard any leading bytes that don't match our address so we resync onto
+  // the real frame as soon as it appears, rather than getting stuck on noise
+  // for the rest of the exchange.
+  while (this->rx_buffer_len_ > 0 && this->rx_buffer_[0] != this->address_) {
+    std::memmove(this->rx_buffer_.data(), this->rx_buffer_.data() + 1, this->rx_buffer_len_ - 1);
+    this->rx_buffer_len_--;
   }
   
   if (this->rx_buffer_len_ < 2) return false;
@@ -157,8 +209,8 @@ void WaterFurnaceAurora::process_response_() {
   
   // Route to appropriate handler.
   // Handlers may chain to a new request (e.g. poll → fault history → dealer info).
-  // Only clear pending_request_ if the handler did NOT chain — detected by the
-  // state still being WAITING_RESPONSE (chained requests transition to TX_PENDING).
+  // Only clear pending_request_ if the handler did NOT chain — see the comment
+  // after this switch for how that's detected.
   switch (this->pending_request_) {
     case PendingRequest::SETUP_ID:
       this->process_setup_id_response_(resp);
@@ -192,10 +244,12 @@ void WaterFurnaceAurora::process_response_() {
   
   // Only clear pending_request_ if the handler did NOT chain to a new request.
   // Chained requests (fault history, dealer info, medium poll) call send_request_()
-  // which transitions state to TX_PENDING and sets pending_request_ to the new type.
-  // Clearing it here would clobber the new request, causing the response to be
-  // silently discarded by the default case above.
-  if (this->state_ != State::TX_PENDING) {
+  // which now transitions state to WAITING_RESPONSE synchronously (see
+  // send_request_common_) and sets pending_request_ to the new type. A
+  // non-chaining handler leaves state_ as IDLE/ERROR_BACKOFF instead.
+  // Clearing pending_request_ here would clobber the new chained request,
+  // causing its response to be silently discarded by the default case above.
+  if (this->state_ != State::WAITING_RESPONSE) {
     this->pending_request_ = PendingRequest::NONE;
   }
 }
@@ -367,17 +421,11 @@ void WaterFurnaceAurora::loop() {
       return;
       
     case State::TX_PENDING:
-      // Wait for UART TX FIFO to drain before switching RS-485 to RX mode.
-      // This avoids calling flush() which would block for up to ~110ms on
-      // large frames at 19200 baud, exceeding the 50ms loop() warning threshold.
-      if (now >= this->tx_complete_time_) {
-        // RS-485 turnaround: switch to RX mode now that TX is complete.
-        // 500µs margin is conservative for MAX485 transceivers.
-        if (this->flow_control_pin_ != nullptr) {
-          this->flow_control_pin_->digital_write(false);
-        }
-        this->transition_(State::WAITING_RESPONSE);
-      }
+      // No longer reachable: send_request_common_() now flips the RS-485
+      // pin and transitions straight to WAITING_RESPONSE synchronously,
+      // right after flush() confirms TX is physically complete. Kept as a
+      // harmless fallback in case anything still lands here.
+      this->transition_(State::WAITING_RESPONSE);
       return;
       
     case State::WAITING_RESPONSE: {

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -64,53 +64,24 @@ void WaterFurnaceAurora::send_request_common_(const uint8_t *frame, size_t frame
   if (this->flow_control_pin_ != nullptr) {
     this->flow_control_pin_->digital_write(true);
   }
-  
-  // Send frame and BLOCK until the UART hardware confirms it has actually left
-  // the wire (flush() -> uart_wait_tx_done() on the esp-idf UART backend).
-  //
-  // NOTE: this used to be non-blocking — write_array() would queue the bytes
-  // and the RS-485 direction pin would be switched back to RX after a
-  // hand-estimated delay (frame_bytes * 11 bits / baud). That estimate is only
-  // valid on backends where write() itself blocks until the data is on the
-  // wire (e.g. the Arduino HardwareSerial framework). On the esp-idf UART
-  // driver, write_array() just copies bytes into a ring buffer and returns
-  // almost immediately — actual transmission happens later, asynchronously,
-  // via interrupt. That mismatch meant the flow-control pin was frequently
-  // flipped to RX mode *before* our own request had finished transmitting,
-  // truncating the outgoing frame and injecting a glitch byte into the RX
-  // path right as the transceiver reversed direction — which desynced the
-  // response parser for the rest of that exchange (see CRC-mismatch/timeout
-  // pattern in the field logs). flush() is the only reliable way to know TX
-  // is actually done. For the frame sizes this component sends (well under
-  // ~150 bytes), that's at most ~90ms at 19200 baud — worth it for correct
-  // framing. If this ever needs to be non-blocking again, the fix has to be
-  // a real completion signal (e.g. polling the driver's TX-done state), not
-  // a bigger fixed delay — a race is still a race no matter the margin.
+
+  // Write then flush() so TX is physically complete before we release DE/RE.
+  // On esp-idf, write_array() only queues into the UART ring buffer; without
+  // flush()/uart_wait_tx_done() an estimated delay races the hardware and can
+  // truncate our own frame. Flip the pin back to RX in this same call stack —
+  // deferring to a later loop() tick misses the head of fast ABC responses
+  // (device-ID 0x03 reads). Matches esphome/components/modbus. Aurora request
+  // frames are small; flush blocks on the order of a few–tens of ms at 19200.
   this->write_array(frame, frame_len);
   this->flush();
-  
-  // IMPORTANT: flip the RS-485 transceiver back to RX and start listening
-  // *synchronously*, right here — do NOT defer this to a future loop() tick
-  // (e.g. via a TX_PENDING state checked against a timestamp). flush() only
-  // guarantees TX is physically done; if we then wait for the *next* call
-  // to loop() to notice that and flip the pin, we introduce a second,
-  // scheduler-dependent gap during which the ESP is still deaf. On a build
-  // with WiFi, the API, web_server, and a couple dozen entities sharing the
-  // loop, that gap is easily long enough (tens of ms) to miss the first
-  // several bytes of a fast-turnaround slave's response — which is exactly
-  // what field logs showed even after making flush() synchronous: captures
-  // that were always a truncated, mid-frame window into the real response,
-  // never starting at the address/function header. Doing the pin flip here,
-  // in the same call stack as flush(), removes that gap entirely.
+
   if (this->flow_control_pin_ != nullptr) {
     this->flow_control_pin_->digital_write(false);
   }
-  
+
   this->pending_request_ = type;
   this->last_request_time_ = millis();
-  // Reference point for the response timeout in the WAITING_RESPONSE state.
-  // TX is already fully complete and we're already listening, so this is
-  // simply "now" — no estimate or margin needed anymore.
+  // Response timeout is measured from TX-complete / start-of-listen.
   this->tx_complete_time_ = millis();
   this->transition_(State::WAITING_RESPONSE);
 }
@@ -134,20 +105,21 @@ bool WaterFurnaceAurora::read_frame_() {
     this->rx_buffer_[this->rx_buffer_len_++] = this->read();
   }
   
-  // Resync guard: a real frame must start with our slave address. If a stray
-  // byte (line noise, a transceiver turnaround glitch, etc.) ever ends up at
-  // the front of rx_buffer_, expected_frame_size() below has no way to know
-  // that — it just trusts byte[0]/byte[1] as address/function and computes a
-  // frame length from whatever garbage is there, which then either never
-  // matches a real boundary (permanent desync until the next timeout) or,
-  // worse, coincidentally "completes" on a bogus length and reports a false
-  // CRC-mismatch frame while quietly discarding real response bytes. Instead,
-  // discard any leading bytes that don't match our address so we resync onto
-  // the real frame as soon as it appears, rather than getting stuck on noise
-  // for the rest of the exchange.
-  while (this->rx_buffer_len_ > 0 && this->rx_buffer_[0] != this->address_) {
-    std::memmove(this->rx_buffer_.data(), this->rx_buffer_.data() + 1, this->rx_buffer_len_ - 1);
-    this->rx_buffer_len_--;
+  // Resync: drop leading noise/glitch bytes until the configured slave address
+  // is at the front. expected_frame_size() trusts byte[0] as the address, so a
+  // single stray prefix would desync the parser for the rest of the exchange.
+  if (this->rx_buffer_len_ > 0 && this->rx_buffer_[0] != this->address_) {
+    size_t start = 0;
+    while (start < this->rx_buffer_len_ && this->rx_buffer_[start] != this->address_) {
+      start++;
+    }
+    if (start >= this->rx_buffer_len_) {
+      this->rx_buffer_len_ = 0;
+    } else if (start > 0) {
+      std::memmove(this->rx_buffer_.data(), this->rx_buffer_.data() + start,
+                   this->rx_buffer_len_ - start);
+      this->rx_buffer_len_ -= start;
+    }
   }
   
   if (this->rx_buffer_len_ < 2) return false;
@@ -209,8 +181,6 @@ void WaterFurnaceAurora::process_response_() {
   
   // Route to appropriate handler.
   // Handlers may chain to a new request (e.g. poll → fault history → dealer info).
-  // Only clear pending_request_ if the handler did NOT chain — see the comment
-  // after this switch for how that's detected.
   switch (this->pending_request_) {
     case PendingRequest::SETUP_ID:
       this->process_setup_id_response_(resp);
@@ -242,13 +212,9 @@ void WaterFurnaceAurora::process_response_() {
       break;
   }
   
-  // Only clear pending_request_ if the handler did NOT chain to a new request.
-  // Chained requests (fault history, dealer info, medium poll) call send_request_()
-  // which now transitions state to WAITING_RESPONSE synchronously (see
-  // send_request_common_) and sets pending_request_ to the new type. A
-  // non-chaining handler leaves state_ as IDLE/ERROR_BACKOFF instead.
-  // Clearing pending_request_ here would clobber the new chained request,
-  // causing its response to be silently discarded by the default case above.
+  // Chained handlers call send_request_*() which leaves state_ as WAITING_RESPONSE
+  // with pending_request_ already set to the new type — do not clobber it.
+  // Non-chaining handlers leave IDLE / ERROR_BACKOFF / setup follow-on states.
   if (this->state_ != State::WAITING_RESPONSE) {
     this->pending_request_ = PendingRequest::NONE;
   }
@@ -420,16 +386,8 @@ void WaterFurnaceAurora::loop() {
       // Otherwise just wait for update() to kick off a poll cycle
       return;
       
-    case State::TX_PENDING:
-      // No longer reachable: send_request_common_() now flips the RS-485
-      // pin and transitions straight to WAITING_RESPONSE synchronously,
-      // right after flush() confirms TX is physically complete. Kept as a
-      // harmless fallback in case anything still lands here.
-      this->transition_(State::WAITING_RESPONSE);
-      return;
-      
     case State::WAITING_RESPONSE: {
-      // Check timeout (measured from when TX completed, not when we started transmitting)
+      // Timeout measured from TX-complete / start-of-listen (see send_request_common_).
       if ((now - this->tx_complete_time_) > RESPONSE_TIMEOUT_MS) {
         this->handle_timeout_();
         return;

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -33,8 +33,7 @@ enum class State : uint8_t {
   SETUP_DETECT_COMPONENTS,  // Detect AXB, VS Drive, IZ2, blower, pump, energy
   SETUP_DETECT_VS,          // VS Drive probe (optional second detect step)
   IDLE,                     // Ready for next operation
-  TX_PENDING,               // Frame written to UART TX FIFO, waiting for transmit to complete
-  WAITING_RESPONSE,         // Request sent, collecting bytes
+  WAITING_RESPONSE,         // Request on the wire, collecting response bytes
   ERROR_BACKOFF,            // Communication error, waiting before retry
 };
 
@@ -429,7 +428,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
  protected:
   // --- State machine operations ---
   void transition_(State new_state);
-  /// Common send logic — flushes bus, toggles RS-485, writes frame, sets timing.
+  /// Common send logic — clear RX, DE/RE TX, write+flush, DE/RE RX, WAITING_RESPONSE.
   void send_request_common_(const uint8_t *frame, size_t frame_len, PendingRequest type);
   /// Send a Modbus request frame and transition to WAITING_RESPONSE.
   void send_request_(const uint8_t *frame, size_t frame_len, PendingRequest type,
@@ -651,7 +650,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   uint32_t last_request_time_{0};
   uint32_t error_backoff_until_{0};
   uint32_t last_successful_response_{0};
-  uint32_t tx_complete_time_{0};  // millis() when TX FIFO is expected to drain
+  uint32_t tx_complete_time_{0};  // millis() when TX completed and RX listening began
   
   // Connectivity
   binary_sensor::BinarySensor *connected_sensor_{nullptr};

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -511,12 +511,6 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   void on_write_register_service_(int32_t address, int32_t value);
 #endif
   
-  /// Estimate TX time in milliseconds for a given frame size at 19200 baud.
-  /// 19200 baud with 8E1 = 11 bits/byte → ~0.573ms/byte. We add 1ms margin.
-  uint32_t tx_time_ms_(size_t frame_bytes) const {
-    return static_cast<uint32_t>((frame_bytes * 11 * 1000) / 19200) + 2;
-  }
-
   // AWL version helpers
   bool awl_axb() const { return this->has_axb_ && this->axb_version_ >= 2.0f; }
   bool awl_thermostat() const { return this->thermostat_version_ >= 3.0f; }

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -5,13 +5,14 @@
 using namespace esphome;
 using namespace esphome::waterfurnace_aurora;
 
-// Helper: advance millis and loop to transition past TX_PENDING → WAITING_RESPONSE.
-// After send_request_, the hub is in TX_PENDING; we need to advance time past the
-// calculated TX completion time.  A 100-register poll frame (~204 bytes) at 19200 baud
-// 8E1 takes ~120ms, so 150ms margin handles the worst case with room to spare.
+// Helper kept for call-site readability after a send.
+// send_request_common_() now completes TX synchronously (write + flush + DE/RE
+// release) and enters WAITING_RESPONSE immediately, so there is no TX_PENDING
+// drain step. We still nudge the test clock and pump loop() once so existing
+// sequences stay deterministic.
 static void complete_tx(WaterFurnaceAurora &hub, uint32_t current_ms) {
-  set_millis(current_ms + 150);  // 150ms covers the largest frames at 19200 baud
-  hub.loop();                    // transitions TX_PENDING → WAITING_RESPONSE
+  set_millis(current_ms + 1);
+  hub.loop();  // already WAITING_RESPONSE — may collect any already-queued RX
 }
 
 // Helper: build a valid func 0x42 response frame from address-value pairs
@@ -224,7 +225,7 @@ TEST_CASE("Setup failure and re-detection", "[hub][state][redetect]") {
   SECTION("setup timeout after MAX_SETUP_RETRIES sets needs_redetect") {
     // Loop through 5 timeout cycles
     for (int i = 0; i < 5; i++) {
-      hub.loop();                  // sends ID request → TX_PENDING
+      hub.loop();                  // sends ID request → WAITING_RESPONSE
       hub.mock_get_transmitted();  // drain tx
       complete_tx(hub, millis());  // WAITING_RESPONSE
       
@@ -375,11 +376,11 @@ TEST_CASE("Connected sensor", "[hub][connectivity]") {
 
     // Simulate the hub marking connected after a successful response
     // by driving a minimal setup flow.
-    hub.loop();  // sends setup ID request → TX_PENDING
+    hub.loop();  // sends setup ID request → WAITING_RESPONSE
     auto tx = hub.mock_get_transmitted();
     REQUIRE(tx.size() > 0);
 
-    complete_tx(hub, 0);  // advance past TX → WAITING_RESPONSE
+    complete_tx(hub, 0);
 
     // Feed a valid ID response (18 regs of spaces)
     std::vector<uint16_t> id_vals(18, 0x2020);
@@ -406,6 +407,51 @@ TEST_CASE("setup() is non-blocking", "[hub][state]") {
   REQUIRE_FALSE(hub.is_setup_complete());
 }
 
+// RS-485 turnaround: DE/RE must be released in the same send path as flush(),
+// before returning to loop(). A deferred release loses the head of fast ABC
+// replies (device-ID 0x03).
+TEST_CASE("RS-485 turnaround releases flow-control pin synchronously", "[hub][state][rs485]") {
+  WaterFurnaceAurora hub;
+  GPIOPin flow_pin;
+  hub.set_flow_control_pin(&flow_pin);
+  set_millis(0);
+
+  hub.setup();
+  hub.loop();  // sends ID request; TX + pin release happen inside send path
+
+  REQUIRE(hub.mock_get_transmitted().size() > 0);
+  REQUIRE_FALSE(flow_pin.state_);  // listening (RX) before next loop() tick
+}
+
+// Leading noise before the slave address must be discarded so expected_frame_size()
+// does not latch onto a false header.
+TEST_CASE("RS-485 resync drops leading noise before slave address", "[hub][state][rs485]") {
+  WaterFurnaceAurora hub;
+  set_millis(0);
+  hub.setup();
+  hub.loop();  // ID request → WAITING_RESPONSE
+  hub.mock_get_transmitted();
+  complete_tx(hub, 0);
+
+  std::vector<uint16_t> id_values(18, 0x2020);
+  auto id_resp = make_response_03(id_values);
+  // Glitch prefix, then a valid frame starting at address 0x01
+  std::vector<uint8_t> noisy = {0xFF, 0x00, 0x55};
+  noisy.insert(noisy.end(), id_resp.begin(), id_resp.end());
+  hub.mock_receive(noisy);
+
+  set_millis(30);
+  hub.loop();
+
+  // Successful ID parse advances setup past SETUP_READ_ID
+  REQUIRE_FALSE(hub.is_setup_complete());  // still needs detect, but...
+  // ...the ID step must have been accepted (next loop sends detect 0x42)
+  hub.loop();
+  auto tx = hub.mock_get_transmitted();
+  REQUIRE(tx.size() > 0);
+  REQUIRE(tx[1] == 0x42);
+}
+
 // Helper: drive a hub through the full setup sequence (ID + detect + VS probe).
 // Returns the hub in IDLE state with setup_complete_ == true.
 // Callers can set overrides before calling this.
@@ -413,16 +459,16 @@ static void drive_setup(WaterFurnaceAurora &hub) {
   hub.setup();
 
   // Step 1: ID request (func 0x03)
-  hub.loop();                  // sends ID request → TX_PENDING
+  hub.loop();                  // sends ID request → WAITING_RESPONSE
   hub.mock_get_transmitted();  // drain tx buffer
-  complete_tx(hub, 0);         // TX_PENDING → WAITING_RESPONSE
+  complete_tx(hub, 0);
   std::vector<uint16_t> id_values(18, 0x2020);
   hub.mock_receive(make_response_03(id_values));
   set_millis(50);
   hub.loop();                  // processes ID → SETUP_DETECT_COMPONENTS
 
   // Step 2: Detect request (func 0x42)
-  hub.loop();                  // sends detect → TX_PENDING
+  hub.loop();                  // sends detect → WAITING_RESPONSE
   auto tx = hub.mock_get_transmitted();
   size_t num_detect_regs = (tx.size() - 4) / 2;
   std::vector<std::pair<uint16_t, uint16_t>> detect_vals;
@@ -443,7 +489,7 @@ static void drive_setup(WaterFurnaceAurora &hub) {
 
   // Step 3: VS probe (no VS drive)
   hub.loop();                  // enters SETUP_DETECT_VS
-  hub.loop();                  // sends VS probe → TX_PENDING
+  hub.loop();                  // sends VS probe → WAITING_RESPONSE
   hub.mock_get_transmitted();  // drain tx buffer
   complete_tx(hub, 100);
   hub.mock_receive(make_response_42({{3001, 0}, {3322, 0}, {3325, 0}}));
@@ -457,13 +503,13 @@ TEST_CASE("Full setup flow with mock UART", "[hub][state][integration]") {
 
   hub.setup();
 
-  // First loop() sends the setup ID request → TX_PENDING
+  // First loop() sends the setup ID request → WAITING_RESPONSE
   hub.loop();
   auto tx = hub.mock_get_transmitted();
   REQUIRE(tx.size() > 0);
   REQUIRE(tx[1] == 0x03);  // func 0x03 holding read for model/serial
 
-  complete_tx(hub, 0);  // TX_PENDING → WAITING_RESPONSE
+  complete_tx(hub, 0);
 
   // Feed a valid response for model/serial (18 regs of spaces)
   std::vector<uint16_t> id_values(18, 0x2020);  // spaces
@@ -473,13 +519,13 @@ TEST_CASE("Full setup flow with mock UART", "[hub][state][integration]") {
   set_millis(50);
   hub.loop();  // Process response, transition to SETUP_DETECT_COMPONENTS
 
-  // Next loop() sends detect request → TX_PENDING
+  // Next loop() sends detect request → WAITING_RESPONSE
   hub.loop();
   tx = hub.mock_get_transmitted();
   REQUIRE(tx.size() > 0);
   REQUIRE(tx[1] == 0x42);  // func 0x42 for detect
 
-  complete_tx(hub, 50);  // TX_PENDING → WAITING_RESPONSE
+  complete_tx(hub, 50);
 
   // Feed a response: AXB=3 (absent), IZ2=3 (absent), thermostat=300 (v3.00),
   // blower=0 (PSC), energy=0, pump=0, ABC program = 0
@@ -504,14 +550,14 @@ TEST_CASE("Full setup flow with mock UART", "[hub][state][integration]") {
   // Since no VS drive detected from program, it should probe VS registers
   // next (SETUP_DETECT_VS).  After processing the detect response the hub
   // transitions to SETUP_DETECT_VS, but that state is entered on the NEXT
-  // loop() call.  We also need complete_tx() to advance past TX_PENDING.
+  // loop() call.  complete_tx() keeps the clock/loop pump consistent.
   hub.loop();  // Process detect response → transitions to SETUP_DETECT_VS
-  hub.loop();  // Enter SETUP_DETECT_VS → send VS probe → TX_PENDING
+  hub.loop();  // Enter SETUP_DETECT_VS → send VS probe → WAITING_RESPONSE
   tx = hub.mock_get_transmitted();
   REQUIRE(tx.size() > 0);
   REQUIRE(tx[1] == 0x42);  // VS probe is also func 0x42
 
-  complete_tx(hub, 100);  // TX_PENDING → WAITING_RESPONSE
+  complete_tx(hub, 100);
 
   // Feed VS probe response with all zeros (no VS drive)
   auto vs_resp = make_response_42({{3001, 0}, {3322, 0}, {3325, 0}});
@@ -548,7 +594,7 @@ TEST_CASE("IZ2 demand sensors", "[hub][iz2][sensors]") {
     
     // Trigger a poll cycle
     set_millis(200);
-    hub.update();  // starts poll → TX_PENDING
+    hub.update();  // starts poll → WAITING_RESPONSE
     auto tx = hub.mock_get_transmitted();
     REQUIRE(tx.size() > 0);
     complete_tx(hub, 200);


### PR DESCRIPTION
The writing and reading of data since the 26.x.x version of esphome was causing issues where the offset for the returned data would be off so the results would fail to process.  A flush was added to make sure data was written before moving on and then additional code made sure the read off set was correct.  