### PR TITLE
fix: poll modulating loop-output registers on open loop (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The component automatically detects installed hardware at startup:
 - **IntelliZone 2**: register 812, zone count from register 483
 - **Blower Type**: register 404 (PSC, ECM, 5-Speed); gates ECM speed controls
 - **Energy Monitor Level**: register 412 (None, Compressor Monitor, Energy Monitor); gates refrigeration and energy registers
-- **Pump Type**: register 413 (Open Loop, FC1, FC2, VS Pump, etc.); gates VS pump speed registers
+- **Pump Type**: register 413 (Open Loop, FC1, FC2, VS Pump, etc.); gates modulating loop-output registers 321–325 for VS pump **and** Open Loop (shared 0–10V / control-valve path). Fixed-speed types (FC1/FC2) are excluded.
 - **AWL Versions**: thermostat (register 801), AXB (register 807), IZ2 (register 813); gates register selection
 
 Sensors that depend on hardware not present show as "Unknown" in Home Assistant. If auto-detection fails, you can add manual overrides to your YAML. These merge with the package configuration (you do not need to redefine the base component):

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -948,9 +948,11 @@ void WaterFurnaceAurora::build_poll_addresses_() {
     }
   }
   
-  // VS pump registers — the Ruby gem gates 321..324 on is_vs_pump (VSPump class),
-  // but only adds 325 (actual speed readback) when awl_axb? is true.
-  if (this->is_vs_pump()) {
+  // Modulating loop-output registers 321-325.
+  // Ruby gem gates these on VSPump (types 3-5) only. We also poll for OPEN_LOOP:
+  // the same 0-10V path drives control valves / VFDs on many open-loop installs
+  // (GitHub issue #30). Actual speed readback (325) still requires awl_axb().
+  if (this->has_modulating_loop_output()) {
     this->add_poll_addr_(registers::VS_PUMP_MANUAL);
     if (this->awl_axb()) {
       this->add_poll_addr_(registers::VS_PUMP_SPEED);
@@ -1013,7 +1015,7 @@ void WaterFurnaceAurora::build_poll_addresses_() {
       this->add_poll_addr_(registers::AUX_HEAT_ECM_SPEED);
     }
     
-    if (this->is_vs_pump()) {
+    if (this->has_modulating_loop_output()) {
       this->add_poll_addr_(registers::VS_PUMP_MIN);
       this->add_poll_addr_(registers::VS_PUMP_MAX);
     }

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -515,7 +515,17 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   bool awl_thermostat() const { return this->thermostat_version_ >= 3.0f; }
   bool awl_iz2() const { return this->has_iz2_ && this->iz2_version_ >= 2.0f; }
   bool is_ecm_blower() const { return this->blower_type_ == BlowerType::ECM_208 || this->blower_type_ == BlowerType::ECM_265; }
-  bool is_vs_pump() const { return this->pump_type_ == PumpType::VS_PUMP || this->pump_type_ == PumpType::VS_PUMP_26_99 || this->pump_type_ == PumpType::VS_PUMP_UPS26_99; }
+  bool is_vs_pump() const {
+    return this->pump_type_ == PumpType::VS_PUMP || this->pump_type_ == PumpType::VS_PUMP_26_99 ||
+           this->pump_type_ == PumpType::VS_PUMP_UPS26_99;
+  }
+  /// True when registers 321-325 (min/max/manual/speed) should be polled.
+  /// VS pump types always qualify. Open loop also qualifies: many installs use the
+  /// same 0-10V output for a modulating control valve or VFD (GitHub issue #30).
+  /// Fixed-speed types (FC1/FC2/GLNP) do not.
+  bool has_modulating_loop_output() const {
+    return this->is_vs_pump() || this->pump_type_ == PumpType::OPEN_LOOP;
+  }
   bool refrigeration_monitoring() const { return this->energy_monitor_level_ >= 1; }
   bool energy_monitoring() const { return this->energy_monitor_level_ >= 2; }
 

--- a/docs/ENTITIES.md
+++ b/docs/ENTITIES.md
@@ -40,7 +40,7 @@ Complete reference of all Home Assistant entities created by this component.
 | `vs_drive_temperature` | °F | VS drive board temperature | 3327 |
 | `vs_inverter_temperature` | °F | VS inverter temperature | 3522 |
 | `blower_speed` | - | Current indoor blower ECM speed | 344 |
-| `pump_speed` | % | Current loop pump speed | 325 |
+| `pump_speed` | % | Current modulating loop output (VS pump or open-loop 0–10V) | 325 |
 | `heating_liquid_line_temperature` | °F | Heating mode liquid line temp | 1109 |
 | `saturated_condenser_temperature` | °F | Saturated condenser temperature | 1134 |
 | `subcool_temperature` | °F | Subcooling temperature | 1135/1136 |
@@ -58,8 +58,8 @@ Complete reference of all Home Assistant entities created by this component.
 | `lo_compressor_speed` | - | Low compressor ECM speed setting | 341 |
 | `hi_compressor_speed` | - | High compressor ECM speed setting | 342 |
 | `aux_heat_speed` | - | Aux electric heat ECM speed setting | 347 |
-| `pump_min_speed` | % | Loop pump minimum speed setting | 321 |
-| `pump_max_speed` | % | Loop pump maximum speed setting | 322 |
+| `pump_min_speed` | % | Loop output minimum setting (VS pump or open loop) | 321 |
+| `pump_max_speed` | % | Loop output maximum setting (VS pump or open loop) | 322 |
 | `humidification_target` | % | Humidification setpoint | 12310/31110 |
 | `dehumidification_target` | % | Dehumidification setpoint | 12310/31110 |
 | `line_voltage_setting` | V | Configured line voltage setting | 112 |
@@ -154,11 +154,11 @@ Complete reference of all Home Assistant entities created by this component.
 | `lo_compressor_speed` | 1-12 | Indoor blower ECM speed for low compressor |
 | `hi_compressor_speed` | 1-12 | Indoor blower ECM speed for high compressor |
 | `aux_heat_speed` | 1-12 | Indoor blower ECM speed for aux electric heat |
-| `pump_min_speed` | 1-100% | Loop pump minimum speed |
-| `pump_max_speed` | 1-100% | Loop pump maximum speed |
+| `pump_min_speed` | 1-100% | Loop output minimum (VS pump or open-loop 0–10V) |
+| `pump_max_speed` | 1-100% | Loop output maximum (VS pump or open-loop 0–10V) |
 | `fan_intermittent_on` | 0-25 min | Fan on time (intermittent mode) |
 | `fan_intermittent_off` | 5-40 min | Fan off time (intermittent mode) |
-| `pump_speed` | 1-100% | Loop pump speed override (requires VS pump) |
+| `pump_speed` | 1-100% | Loop output override (VS pump or open loop; requires AXB ≥ v2 for readback) |
 | `humidification_target` | 15-50% | Humidification setpoint (see [Humidity Control](#humidity-control)) |
 | `dehumidification_target` | 35-65% | Dehumidification setpoint (see [Humidity Control](#humidity-control)) |
 | `line_voltage_setting` | 90-635 V | Configured line voltage (register 112) |
@@ -176,7 +176,7 @@ Complete reference of all Home Assistant entities created by this component.
 | Switch | Description |
 | :--- | :--- |
 | `dhw_enabled` | Enable/disable domestic hot water (legacy; superseded by water_heater entity) |
-| `pump_manual_control` | VS pump manual override (writes current speed or auto to register 323) |
+| `pump_manual_control` | Manual override for modulating loop output (writes speed or auto/`0x7FFF` to register 323); VS pump or open loop |
 
 ## Buttons
 

--- a/local_dev.yaml
+++ b/local_dev.yaml
@@ -144,8 +144,8 @@ switch:
     # Uncomment if you prefer separate switch + number controls instead.
     # dhw_enabled:
     #   name: "DHW Enabled"
-    # VS pump manual override (requires variable speed pump)
-    # When enabled, loop pump runs at the current speed; writing 0x7FFF returns to auto.
+    # Modulating loop-output manual override (VS pump or Open Loop 0-10V path)
+    # When enabled, loop output runs at the current speed; writing 0x7FFF returns to auto.
     # pump_manual_control:
     #   name: "Pump Manual Control"
 
@@ -170,8 +170,8 @@ number:
       name: "High Compressor ECM Speed"
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed"
-    # Loop Pump speed settings (1-100%)
-    # NOTE: Requires variable speed (VS) pump. Shows "Unknown" on fixed-speed pumps.
+    # Loop output speed settings (1-100%)
+    # NOTE: Requires VS pump or Open Loop (0-10V valve/VFD path). Unknown on FC1/FC2 fixed-speed.
     pump_min_speed:
       name: "Loop Pump Minimum Speed"
     pump_max_speed:
@@ -320,7 +320,7 @@ sensor:
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed Setting"
     
-    # Loop Pump speeds (requires variable speed pump; show "Unknown" on fixed-speed pumps)
+    # Loop output speeds (VS pump or Open Loop 0-10V; Unknown on FC1/FC2 fixed-speed)
     pump_speed:
       name: "Loop Pump Speed"
     pump_min_speed:

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -1207,7 +1207,7 @@ static void drive_setup_with_pump(WaterFurnaceAurora &hub, uint16_t pump_type_va
   REQUIRE(hub.is_setup_complete());
 }
 
-TEST_CASE("VS pump register gating matches Ruby gem", "[hub][pump][poll]") {
+TEST_CASE("Modulating loop-output register gating", "[hub][pump][poll]") {
   // Trigger a poll and return the set of requested addresses
   auto get_poll_addrs = [](WaterFurnaceAurora &hub, uint32_t time_ms) -> std::set<uint16_t> {
     set_millis(time_ms);
@@ -1270,22 +1270,59 @@ TEST_CASE("VS pump register gating matches Ruby gem", "[hub][pump][poll]") {
     REQUIRE(all_addrs.count(registers::VS_PUMP_MAX) == 1);  // 322
   }
 
-  SECTION("non-VS pump + AXB: does NOT poll VS pump registers") {
-    // AXB v2.00 but pump type 0 (OPEN_LOOP) — is_vs_pump() is false
+  SECTION("OPEN_LOOP + AXB v2.x: polls 321, 322, 323, AND 325 (modulating 0-10V path)") {
+    // Open loop shares the VS pump register bank for control valve / VFD output.
+    // Extension beyond Ruby gem VSPump gating — see GitHub issue #30.
     WaterFurnaceAurora hub;
     set_millis(0);
     drive_setup_with_pump(hub, 0, 200, true);  // pump=OPEN_LOOP, axb=v2.00
 
-    // Run enough polls to cover all tiers
+    auto addrs = get_poll_addrs(hub, 200);
+    REQUIRE(addrs.count(registers::VS_PUMP_MANUAL) == 1);  // 323
+    REQUIRE(addrs.count(registers::VS_PUMP_SPEED) == 1);   // 325 — awl_axb
+
+    std::set<uint16_t> all_addrs;
+    for (int i = 0; i < 7; i++) {
+      auto a = get_poll_addrs(hub, 300 + i * 100);
+      all_addrs.insert(a.begin(), a.end());
+    }
+    REQUIRE(all_addrs.count(registers::VS_PUMP_MIN) == 1);  // 321
+    REQUIRE(all_addrs.count(registers::VS_PUMP_MAX) == 1);  // 322
+  }
+
+  SECTION("OPEN_LOOP + AXB v1.x: polls 321, 322, 323 but NOT 325") {
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_with_pump(hub, 0, 101, true);  // pump=OPEN_LOOP, axb=v1.01
+
+    auto addrs = get_poll_addrs(hub, 200);
+    REQUIRE(addrs.count(registers::VS_PUMP_MANUAL) == 1);  // 323
+    REQUIRE(addrs.count(registers::VS_PUMP_SPEED) == 0);   // 325 needs awl_axb
+
+    std::set<uint16_t> all_addrs;
+    for (int i = 0; i < 7; i++) {
+      auto a = get_poll_addrs(hub, 300 + i * 100);
+      all_addrs.insert(a.begin(), a.end());
+    }
+    REQUIRE(all_addrs.count(registers::VS_PUMP_MIN) == 1);
+    REQUIRE(all_addrs.count(registers::VS_PUMP_MAX) == 1);
+  }
+
+  SECTION("FC1 fixed-speed + AXB: does NOT poll modulating loop-output registers") {
+    // FC1 (type 1) is a fixed-speed circulator config — must stay gated off.
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_with_pump(hub, 1, 200, true);  // pump=FC1, axb=v2.00
+
     std::set<uint16_t> all_addrs;
     for (int i = 0; i < 7; i++) {
       auto a = get_poll_addrs(hub, 200 + i * 100);
       all_addrs.insert(a.begin(), a.end());
     }
-    REQUIRE(all_addrs.count(registers::VS_PUMP_MIN) == 0);    // 321
-    REQUIRE(all_addrs.count(registers::VS_PUMP_MAX) == 0);    // 322
-    REQUIRE(all_addrs.count(registers::VS_PUMP_MANUAL) == 0); // 323
-    REQUIRE(all_addrs.count(registers::VS_PUMP_SPEED) == 0);  // 325
+    REQUIRE(all_addrs.count(registers::VS_PUMP_MIN) == 0);
+    REQUIRE(all_addrs.count(registers::VS_PUMP_MAX) == 0);
+    REQUIRE(all_addrs.count(registers::VS_PUMP_MANUAL) == 0);
+    REQUIRE(all_addrs.count(registers::VS_PUMP_SPEED) == 0);
   }
 }
 

--- a/waterfurnace_aurora.yaml
+++ b/waterfurnace_aurora.yaml
@@ -130,8 +130,8 @@ switch:
     # Uncomment if you prefer separate switch + number controls instead.
     # dhw_enabled:
     #   name: "DHW Enabled"
-    # VS pump manual override (requires variable speed pump)
-    # When enabled, loop pump runs at the current speed; writing 0x7FFF returns to auto.
+    # Modulating loop-output manual override (VS pump or Open Loop 0-10V path)
+    # When enabled, loop output runs at the current speed; writing 0x7FFF returns to auto.
     # pump_manual_control:
     #   name: "Pump Manual Control"
 
@@ -156,8 +156,8 @@ number:
       name: "High Compressor ECM Speed"
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed"
-    # Loop Pump speed settings (1-100%)
-    # NOTE: Requires variable speed (VS) pump. Shows "Unknown" on fixed-speed pumps.
+    # Loop output speed settings (1-100%)
+    # NOTE: Requires VS pump or Open Loop (0-10V valve/VFD path). Unknown on FC1/FC2 fixed-speed.
     pump_min_speed:
       name: "Loop Pump Minimum Speed"
     pump_max_speed:
@@ -306,7 +306,7 @@ sensor:
     aux_heat_speed:
       name: "Aux Electric Heat ECM Speed Setting"
     
-    # Loop Pump speeds (requires variable speed pump; show "Unknown" on fixed-speed pumps)
+    # Loop output speeds (VS pump or Open Loop 0-10V; Unknown on FC1/FC2 fixed-speed)
     pump_speed:
       name: "Loop Pump Speed"
     pump_min_speed:


### PR DESCRIPTION
## Summary
- Poll registers 321–325 when pump type is Open Loop as well as VS pump
- New helper `has_modulating_loop_output()`; FC1/FC2 remain excluded
- Field-test branch for #30 before merge

## Test plan
- [x] `cd tests && make test`
- [ ] @GruxTheDuck report on #30 flashes branch and confirms pump min/max/speed populate
- [ ] @GruxTheDuck confirms writes (optional, careful) or at least stable readbacks
- [ ] Loop pressure behavior unchanged (out of scope; still AXB + validity filter)