### PR TITLE
fix: non-AWL / dry-contact climate and setpoint gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ An ESPHome/C++ port of the [waterfurnace_aurora Ruby gem](https://github.com/ccu
 - Fan modes (Auto, Continuous, Intermittent)
 - Dual setpoint control (heating and cooling setpoints)
 - IZ2 zone support with per-zone climate entities
+- Dry-contact (non-AWL) wall thermostats: climate is status-oriented (action +
+  return-air temp); setpoints/mode writes require AWL thermostat or IZ2
 
 ### Monitoring
 - **Temperatures**: Entering/leaving air, entering/leaving water, outdoor, ambient

--- a/components/waterfurnace_aurora/climate/aurora_climate.cpp
+++ b/components/waterfurnace_aurora/climate/aurora_climate.cpp
@@ -41,6 +41,9 @@ void AuroraClimate::dump_config() {
     ESP_LOGCONFIG(TAG, "  Mode: %s", this->is_iz2_mode_() ? "IZ2" : "thermostat");
     if (this->is_iz2_mode_()) {
       ESP_LOGCONFIG(TAG, "  IZ2 zones: %d", this->parent_->get_num_iz2_zones());
+    } else {
+      ESP_LOGCONFIG(TAG, "  AWL thermostat controls: %s",
+                    this->parent_->has_awl_thermostat_controls() ? "yes" : "no (status-only)");
     }
   }
   ESP_LOGCONFIG(TAG, "  EMA alpha: %.2f", EMA_ALPHA);
@@ -305,79 +308,79 @@ void AuroraClimate::update_state_() {
       }
     }
   } else {
-    // === Thermostat path: read from system-wide registers ===
+    // === Thermostat path: system-wide registers (AWL) or status-only (dry-contact) ===
 
-    // Update current temperature (hardware reports °F, climate entity uses °C).
-    // EMA smoothing applied here too — the main thermostat sensor can also jitter.
-    float ambient = this->parent_->get_ambient_temperature();
-    if (!std::isnan(ambient)) {
-      float raw_c = fahrenheit_to_celsius(ambient);
+    // Current temperature: AWL ambient, else entering-air fallback (hub helper).
+    float temp_f = this->parent_->get_climate_current_temperature_f();
+    if (!std::isnan(temp_f)) {
+      float raw_c = fahrenheit_to_celsius(temp_f);
       this->current_temperature = apply_ema(raw_c, this->temp_ema_, EMA_ALPHA);
     }
 
-    // Update setpoints (hardware reports °F, climate entity uses °C)
-    // Skip during write cooldown — prevents stale device read-back from
-    // overwriting the optimistic value set by control().
-    if (!this->parent_->setpoint_cooldown_active()) {
-      float heating_sp = this->parent_->get_heating_setpoint();
-      if (!std::isnan(heating_sp)) {
-        this->target_temperature_low = fahrenheit_to_celsius(heating_sp);
+    if (this->parent_->has_awl_thermostat_controls()) {
+      // Update setpoints (hardware reports °F, climate entity uses °C)
+      // Skip during write cooldown — prevents stale device read-back from
+      // overwriting the optimistic value set by control().
+      if (!this->parent_->setpoint_cooldown_active()) {
+        float heating_sp = this->parent_->get_heating_setpoint();
+        if (!std::isnan(heating_sp)) {
+          this->target_temperature_low = fahrenheit_to_celsius(heating_sp);
+        }
+        float cooling_sp = this->parent_->get_cooling_setpoint();
+        if (!std::isnan(cooling_sp)) {
+          this->target_temperature_high = fahrenheit_to_celsius(cooling_sp);
+        }
       }
-      float cooling_sp = this->parent_->get_cooling_setpoint();
-      if (!std::isnan(cooling_sp)) {
-        this->target_temperature_high = fahrenheit_to_celsius(cooling_sp);
+
+      // Update mode and preset (skip during mode cooldown)
+      if (!this->parent_->mode_cooldown_active()) {
+        climate::ClimateMode new_mode;
+        climate::ClimatePreset new_preset;
+        if (aurora_to_esphome_mode(this->parent_->get_hvac_mode(), new_mode, new_preset)) {
+          this->mode = new_mode;
+          this->preset = new_preset;
+        }
       }
+
+      // Update fan mode (skip during fan cooldown)
+      if (!this->parent_->fan_cooldown_active()) {
+        FanMode aurora_fan = this->parent_->get_fan_mode();
+        auto builtin = aurora_to_esphome_fan(aurora_fan);
+        if (builtin.has_value()) {
+          this->set_fan_mode_(*builtin);
+        } else {
+          this->set_custom_fan_mode_(CUSTOM_FAN_MODE_INTERMITTENT);
+        }
+      }
+    } else {
+      // Dry-contact / non-AWL: clear bogus targets; do not claim mode/fan from AWL regs
+      this->target_temperature_low = NAN;
+      this->target_temperature_high = NAN;
+      this->target_humidity = NAN;
     }
 
-    // Update mode and preset (skip during mode cooldown)
-    if (!this->parent_->mode_cooldown_active()) {
-      climate::ClimateMode new_mode;
-      climate::ClimatePreset new_preset;
-      if (aurora_to_esphome_mode(this->parent_->get_hvac_mode(), new_mode, new_preset)) {
-        this->mode = new_mode;
-        this->preset = new_preset;
-      }
-    }
-
-    // Update action based on system outputs
+    // Action always tracks equipment outputs (AWL and dry-contact)
     uint16_t outputs = this->parent_->get_system_outputs();
     bool compressor = (outputs & (OUTPUT_CC | OUTPUT_CC2)) != 0;
     bool cooling = (outputs & OUTPUT_RV) != 0;
     bool aux_heat = (outputs & (OUTPUT_EH1 | OUTPUT_EH2)) != 0;
     bool blower = (outputs & OUTPUT_BLOWER) != 0;
-    // Dehumidifier detection: VS active dehumidify is gated on reversing valve (cooling
-    // mode only); AXB dehumidifier relay is gated on has_dehumidifier() (DIP switch).
     bool dehumidifying = (this->parent_->is_active_dehumidify() && cooling)
                          || (this->parent_->has_dehumidifier()
                              && (this->parent_->get_axb_outputs() & AXB_OUTPUT_DEHUMIDIFIER) != 0);
-    
+
     if (this->parent_->is_locked_out()) {
       this->action = climate::CLIMATE_ACTION_OFF;
     } else if (compressor && cooling) {
-      // During cooling, show DRYING if actively dehumidifying
       this->action = dehumidifying ? climate::CLIMATE_ACTION_DRYING : climate::CLIMATE_ACTION_COOLING;
     } else if (compressor || aux_heat) {
       this->action = climate::CLIMATE_ACTION_HEATING;
     } else if (dehumidifying) {
-      // Standalone dehumidifier running (AXB relay) without compressor
       this->action = climate::CLIMATE_ACTION_DRYING;
     } else if (blower) {
       this->action = climate::CLIMATE_ACTION_FAN;
     } else {
       this->action = climate::CLIMATE_ACTION_IDLE;
-    }
-
-    // Update fan mode (skip during fan cooldown)
-    // Use set_fan_mode_() / set_custom_fan_mode_() to ensure mutual exclusion —
-    // set_fan_mode_() clears custom_fan_mode, set_custom_fan_mode_() clears fan_mode.
-    if (!this->parent_->fan_cooldown_active()) {
-      FanMode aurora_fan = this->parent_->get_fan_mode();
-      auto builtin = aurora_to_esphome_fan(aurora_fan);
-      if (builtin.has_value()) {
-        this->set_fan_mode_(*builtin);
-      } else {
-        this->set_custom_fan_mode_(CUSTOM_FAN_MODE_INTERMITTENT);
-      }
     }
   }
 
@@ -389,10 +392,10 @@ void AuroraClimate::update_state_() {
     this->current_humidity = rh;
   }
 
-  // Update target humidity (mode-aware: humidification in heat, dehumidification in cool)
-  // Humidistat is system-wide — all IZ2 zones share the same targets, but each zone's
-  // slider reflects the target relevant to that zone's operating mode.
-  if (!this->parent_->humidity_target_cooldown_active()) {
+  // Target humidity — gated via has_humidistat_targets inside helper; force NAN on dry-contact
+  if (!this->is_iz2_mode_() && !this->parent_->has_awl_thermostat_controls()) {
+    this->target_humidity = NAN;
+  } else if (!this->parent_->humidity_target_cooldown_active()) {
     float humidity_target = read_mode_humidity_target(this->parent_, this->mode);
     if (!std::isnan(humidity_target)) {
       this->target_humidity = humidity_target;

--- a/components/waterfurnace_aurora/climate/aurora_climate.cpp
+++ b/components/waterfurnace_aurora/climate/aurora_climate.cpp
@@ -353,10 +353,13 @@ void AuroraClimate::update_state_() {
         }
       }
     } else {
-      // Dry-contact / non-AWL: clear bogus targets; do not claim mode/fan from AWL regs
+      // Dry-contact / non-AWL: clear bogus temp targets; do not claim mode/fan from AWL regs.
+      // Temperature NANs are fine — HA's esphome_float_state_property filters them to None.
+      // Do NOT set target_humidity = NAN here: Climate advertises TARGET_HUMIDITY, and HA's
+      // EsphomeClimateEntity.target_humidity does round(value) without an isfinite() guard.
+      // round(nan) raises ValueError and leaves the climate entity permanently unavailable.
       this->target_temperature_low = NAN;
       this->target_temperature_high = NAN;
-      this->target_humidity = NAN;
     }
 
     // Action always tracks equipment outputs (AWL and dry-contact)
@@ -392,10 +395,10 @@ void AuroraClimate::update_state_() {
     this->current_humidity = rh;
   }
 
-  // Target humidity — gated via has_humidistat_targets inside helper; force NAN on dry-contact
-  if (!this->is_iz2_mode_() && !this->parent_->has_awl_thermostat_controls()) {
-    this->target_humidity = NAN;
-  } else if (!this->parent_->humidity_target_cooldown_active()) {
+  // Target humidity — helper returns NAN without has_humidistat_targets() or bad cache.
+  // Only assign when finite. Never force NAN onto the climate field (HA round() crash; see
+  // dry-contact branch comment above). Default/zero remains until a real target arrives.
+  if (!this->parent_->humidity_target_cooldown_active()) {
     float humidity_target = read_mode_humidity_target(this->parent_, this->mode);
     if (!std::isnan(humidity_target)) {
       this->target_humidity = humidity_target;

--- a/components/waterfurnace_aurora/climate/aurora_climate_utils.h
+++ b/components/waterfurnace_aurora/climate/aurora_climate_utils.h
@@ -150,6 +150,8 @@ inline bool route_humidity_write(WaterFurnaceAurora *hub, climate::ClimateMode m
 /// Returns the target value (humidification for heat modes, dehumidification for cool),
 /// or NAN if the register is not cached.
 inline float read_mode_humidity_target(WaterFurnaceAurora *hub, climate::ClimateMode mode) {
+  if (hub == nullptr || !hub->has_humidistat_targets()) return NAN;
+
   uint16_t target_reg = (hub->has_iz2() && hub->awl_communicating())
                             ? registers::IZ2_HUMIDISTAT_TARGETS
                             : registers::HUMIDISTAT_TARGETS;
@@ -157,13 +159,18 @@ inline float read_mode_humidity_target(WaterFurnaceAurora *hub, climate::Climate
   if (std::isnan(raw)) return NAN;
 
   uint16_t packed = static_cast<uint16_t>(raw);
+  uint8_t byte = 0;
   switch (mode) {
     case climate::CLIMATE_MODE_COOL:
-      return static_cast<float>(packed & 0xFF);          // Low byte: dehumidification
+      byte = static_cast<uint8_t>(packed & 0xFF);  // Low byte: dehumidification
+      if (byte == 0 || byte == 0xFF || byte < 35 || byte > 65) return NAN;
+      return static_cast<float>(byte);
     case climate::CLIMATE_MODE_HEAT:
     case climate::CLIMATE_MODE_HEAT_COOL:
     default:
-      return static_cast<float>((packed >> 8) & 0xFF);   // High byte: humidification
+      byte = static_cast<uint8_t>((packed >> 8) & 0xFF);  // High byte: humidification
+      if (byte == 0 || byte == 0xFF || byte < 15 || byte > 50) return NAN;
+      return static_cast<float>(byte);
   }
 }
 

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -2087,6 +2087,13 @@ void WaterFurnaceAurora::process_pending_writes_() {
 // ============================================================================
 
 bool WaterFurnaceAurora::set_heating_setpoint(float temp) {
+  if (!this->awl_thermostat()) {
+    ESP_LOGW(TAG,
+             "Ignoring heating setpoint write — no AWL communicating thermostat "
+             "(dry-contact / Tstat v%.2f)",
+             this->thermostat_version_);
+    return false;
+  }
   if (temp < 40.0f || temp > 90.0f) {
     ESP_LOGW(TAG, "Heating setpoint %.1f out of range (40-90)", temp);
     return false;
@@ -2099,6 +2106,13 @@ bool WaterFurnaceAurora::set_heating_setpoint(float temp) {
 }
 
 bool WaterFurnaceAurora::set_cooling_setpoint(float temp) {
+  if (!this->awl_thermostat()) {
+    ESP_LOGW(TAG,
+             "Ignoring cooling setpoint write — no AWL communicating thermostat "
+             "(dry-contact / Tstat v%.2f)",
+             this->thermostat_version_);
+    return false;
+  }
   if (temp < 54.0f || temp > 99.0f) {
     ESP_LOGW(TAG, "Cooling setpoint %.1f out of range (54-99)", temp);
     return false;
@@ -2111,6 +2125,13 @@ bool WaterFurnaceAurora::set_cooling_setpoint(float temp) {
 }
 
 bool WaterFurnaceAurora::set_hvac_mode(HeatingMode mode) {
+  if (!this->awl_thermostat()) {
+    ESP_LOGW(TAG,
+             "Ignoring HVAC mode write — no AWL communicating thermostat "
+             "(dry-contact / Tstat v%.2f)",
+             this->thermostat_version_);
+    return false;
+  }
   this->write_register(registers::HEATING_MODE_WRITE, static_cast<uint16_t>(mode));
   this->hvac_mode_ = mode;  // Optimistic update — prevents stale read-back during cooldown
   this->last_mode_write_ = millis();
@@ -2118,6 +2139,13 @@ bool WaterFurnaceAurora::set_hvac_mode(HeatingMode mode) {
 }
 
 bool WaterFurnaceAurora::set_fan_mode(FanMode mode) {
+  if (!this->awl_thermostat()) {
+    ESP_LOGW(TAG,
+             "Ignoring fan mode write — no AWL communicating thermostat "
+             "(dry-contact / Tstat v%.2f)",
+             this->thermostat_version_);
+    return false;
+  }
   this->write_register(registers::FAN_MODE_WRITE, static_cast<uint16_t>(mode));
   this->fan_mode_ = mode;  // Optimistic update — prevents stale read-back during cooldown
   this->last_fan_write_ = millis();
@@ -2213,6 +2241,13 @@ bool WaterFurnaceAurora::set_line_voltage_setting(uint16_t voltage) {
 }
 
 bool WaterFurnaceAurora::set_fan_intermittent_on(uint8_t minutes) {
+  if (!this->awl_thermostat()) {
+    ESP_LOGW(TAG,
+             "Ignoring fan intermittent on write — no AWL communicating thermostat "
+             "(dry-contact / Tstat v%.2f)",
+             this->thermostat_version_);
+    return false;
+  }
   if (minutes > 25 || (minutes % 5) != 0) {
     ESP_LOGW(TAG, "Fan on time %d invalid", minutes);
     return false;
@@ -2222,6 +2257,13 @@ bool WaterFurnaceAurora::set_fan_intermittent_on(uint8_t minutes) {
 }
 
 bool WaterFurnaceAurora::set_fan_intermittent_off(uint8_t minutes) {
+  if (!this->awl_thermostat()) {
+    ESP_LOGW(TAG,
+             "Ignoring fan intermittent off write — no AWL communicating thermostat "
+             "(dry-contact / Tstat v%.2f)",
+             this->thermostat_version_);
+    return false;
+  }
   if (minutes < 5 || minutes > 40 || (minutes % 5) != 0) {
     ESP_LOGW(TAG, "Fan off time %d invalid", minutes);
     return false;
@@ -2231,6 +2273,12 @@ bool WaterFurnaceAurora::set_fan_intermittent_off(uint8_t minutes) {
 }
 
 bool WaterFurnaceAurora::set_humidification_target(uint8_t percent) {
+  if (!this->has_humidistat_targets()) {
+    ESP_LOGW(TAG,
+             "Ignoring humidification target write — humidistat targets unavailable "
+             "(need AWL + humidifier/dehumidifier/VS)");
+    return false;
+  }
   if (percent < 15 || percent > 50) {
     ESP_LOGW(TAG, "Humidification target %d out of range (15-50)", percent);
     return false;
@@ -2250,6 +2298,12 @@ bool WaterFurnaceAurora::set_humidification_target(uint8_t percent) {
 }
 
 bool WaterFurnaceAurora::set_dehumidification_target(uint8_t percent) {
+  if (!this->has_humidistat_targets()) {
+    ESP_LOGW(TAG,
+             "Ignoring dehumidification target write — humidistat targets unavailable "
+             "(need AWL + humidifier/dehumidifier/VS)");
+    return false;
+  }
   if (percent < 35 || percent > 65) {
     ESP_LOGW(TAG, "Dehumidification target %d out of range (35-65)", percent);
     return false;
@@ -2268,6 +2322,12 @@ bool WaterFurnaceAurora::set_dehumidification_target(uint8_t percent) {
 }
 
 bool WaterFurnaceAurora::set_humidifier_mode(bool auto_mode) {
+  if (!this->has_humidistat_targets()) {
+    ESP_LOGW(TAG,
+             "Ignoring humidifier mode write — humidistat targets unavailable "
+             "(need AWL + humidifier/dehumidifier/VS)");
+    return false;
+  }
   // Read current settings register to preserve other bits (like the Ruby gem does)
   uint16_t read_reg = (this->has_iz2_ && this->awl_communicating())
                           ? registers::IZ2_HUMIDISTAT_MODE
@@ -2290,6 +2350,12 @@ bool WaterFurnaceAurora::set_humidifier_mode(bool auto_mode) {
 }
 
 bool WaterFurnaceAurora::set_dehumidifier_mode(bool auto_mode) {
+  if (!this->has_humidistat_targets()) {
+    ESP_LOGW(TAG,
+             "Ignoring dehumidifier mode write — humidistat targets unavailable "
+             "(need AWL + humidifier/dehumidifier/VS)");
+    return false;
+  }
   uint16_t read_reg = (this->has_iz2_ && this->awl_communicating())
                           ? registers::IZ2_HUMIDISTAT_MODE
                           : registers::HUMIDISTAT_SETTINGS;

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -888,15 +888,17 @@ void WaterFurnaceAurora::build_poll_addresses_() {
   
   this->add_poll_addr_(registers::FP1_TEMP);
   this->add_poll_addr_(registers::FP2_TEMP);
-  this->add_poll_addr_(registers::AMBIENT_TEMP);
-  
-  // Setpoints, mode, and fan config on fast tier — these are writable from HA
-  // and must be polled frequently so the write cooldown window (7s) always
-  // contains at least one fresh read-back.  Only 4 extra registers per cycle.
-  this->add_poll_addr_(registers::HEATING_SETPOINT);
-  this->add_poll_addr_(registers::COOLING_SETPOINT);
-  this->add_poll_addr_(registers::HEATING_MODE_READ);
-  this->add_poll_addr_(registers::FAN_CONFIG);
+
+  // Thermostat ambient/setpoints/mode/fan — only meaningful with AWL thermostat
+  // (gem Thermostat#registers_to_read gated on awl_thermostat?).
+  if (this->awl_thermostat()) {
+    this->add_poll_addr_(registers::AMBIENT_TEMP);
+    // Writable from HA — poll frequently so write cooldown always has a fresh read-back.
+    this->add_poll_addr_(registers::HEATING_SETPOINT);
+    this->add_poll_addr_(registers::COOLING_SETPOINT);
+    this->add_poll_addr_(registers::HEATING_MODE_READ);
+    this->add_poll_addr_(registers::FAN_CONFIG);
+  }
   
   if (this->awl_axb()) {
     this->add_poll_addr_(registers::ENTERING_AIR_AWL);
@@ -1066,13 +1068,16 @@ void WaterFurnaceAurora::build_poll_addresses_() {
       this->add_poll_addr_(registers::VS_ALARM2);
     }
     
-    if (this->has_iz2_ && this->awl_communicating()) {
-      this->add_poll_addr_(registers::IZ2_HUMIDISTAT_SETTINGS);
-      this->add_poll_addr_(registers::IZ2_HUMIDISTAT_MODE);
-      this->add_poll_addr_(registers::IZ2_HUMIDISTAT_TARGETS);
-    } else {
-      this->add_poll_addr_(registers::HUMIDISTAT_SETTINGS);
-      this->add_poll_addr_(registers::HUMIDISTAT_TARGETS);
+    // Gem: humidistat target/settings regs only when awl_communicating && (hum/dehum/VS)
+    if (this->has_humidistat_targets()) {
+      if (this->has_iz2_ && this->awl_communicating()) {
+        this->add_poll_addr_(registers::IZ2_HUMIDISTAT_SETTINGS);
+        this->add_poll_addr_(registers::IZ2_HUMIDISTAT_MODE);
+        this->add_poll_addr_(registers::IZ2_HUMIDISTAT_TARGETS);
+      } else {
+        this->add_poll_addr_(registers::HUMIDISTAT_SETTINGS);
+        this->add_poll_addr_(registers::HUMIDISTAT_TARGETS);
+      }
     }
     
     // AXB diagnostic sensors — only poll if at least one is configured
@@ -1512,24 +1517,28 @@ void WaterFurnaceAurora::publish_system_status_sensors_(const RegisterMap &regs)
 }
 
 void WaterFurnaceAurora::publish_temperature_sensors_(const RegisterMap &regs) {
-  // Temperatures
-  {
+  // Temperatures — ambient only valid with AWL thermostat (gem gates reg 502)
+  if (this->awl_thermostat()) {
     const uint16_t *val_amb = reg_find(regs, registers::AMBIENT_TEMP);
     if (val_amb) {
       this->ambient_temp_ = to_signed_tenths(*val_amb);
       if (sensor_value_changed_(this->ambient_temperature_sensor_, this->ambient_temp_))
         this->ambient_temperature_sensor_->publish_state(this->ambient_temp_);
     }
+  } else {
+    this->ambient_temp_ = NAN;
   }
-  
+
   // Entering air (return air) — suppress zero readings (register returns 0 when
   // the sensor is absent or the system is not AWL-communicating).  The Ruby gem
   // does: `unless entering_air_temperature.zero?`
+  // Cache for climate current-temp fallback on dry-contact installs.
   {
     uint16_t entering_air_reg = this->awl_axb() ? registers::ENTERING_AIR_AWL : registers::ENTERING_AIR;
     const uint16_t *val = reg_find(regs, entering_air_reg);
     if (val && *val != 0) {
       float fval = to_signed_tenths(*val);
+      this->entering_air_temp_ = fval;
       if (sensor_value_changed_(this->entering_air_temperature_sensor_, fval))
         this->entering_air_temperature_sensor_->publish_state(fval);
     }
@@ -1561,24 +1570,41 @@ void WaterFurnaceAurora::publish_temperature_sensors_(const RegisterMap &regs) {
   {
     const uint16_t *val_rh = reg_find(regs, registers::RELATIVE_HUMIDITY);
     if (val_rh) {
-      this->relative_humidity_ = static_cast<float>(*val_rh);
+      float rh = static_cast<float>(*val_rh);
+      if (rh > 100.0f) {
+        rh = NAN;  // includes 0xFF / 255 unpopulated
+      }
+      this->relative_humidity_ = rh;
       if (this->humidity_sensor_ != nullptr &&
           sensor_value_changed_(this->humidity_sensor_, this->relative_humidity_))
         this->humidity_sensor_->publish_state(this->relative_humidity_);
     }
   }
-  
-  // Setpoints (respect write cooldown)
-  if ((millis() - this->last_setpoint_write_) > WRITE_COOLDOWN_MS) {
+
+  // Setpoints — only with AWL thermostat; sanitize gem-valid ranges
+  if (!this->awl_thermostat()) {
+    this->heating_setpoint_ = NAN;
+    this->cooling_setpoint_ = NAN;
+  } else if ((millis() - this->last_setpoint_write_) > WRITE_COOLDOWN_MS) {
     const uint16_t *val_hsp = reg_find(regs, registers::HEATING_SETPOINT);
     if (val_hsp) {
-      this->heating_setpoint_ = to_tenths(*val_hsp);
+      float v = to_tenths(*val_hsp);
+      if (std::isnan(v) || v < 40.0f || v > 90.0f) {
+        this->heating_setpoint_ = NAN;
+      } else {
+        this->heating_setpoint_ = v;
+      }
       if (sensor_value_changed_(this->heating_setpoint_sensor_, this->heating_setpoint_))
         this->heating_setpoint_sensor_->publish_state(this->heating_setpoint_);
     }
     const uint16_t *val_csp = reg_find(regs, registers::COOLING_SETPOINT);
     if (val_csp) {
-      this->cooling_setpoint_ = to_tenths(*val_csp);
+      float v = to_tenths(*val_csp);
+      if (std::isnan(v) || v < 54.0f || v > 99.0f) {
+        this->cooling_setpoint_ = NAN;
+      } else {
+        this->cooling_setpoint_ = v;
+      }
       if (sensor_value_changed_(this->cooling_setpoint_sensor_, this->cooling_setpoint_))
         this->cooling_setpoint_sensor_->publish_state(this->cooling_setpoint_);
     }
@@ -1607,8 +1633,8 @@ void WaterFurnaceAurora::publish_temperature_sensors_(const RegisterMap &regs) {
 }
 
 void WaterFurnaceAurora::publish_mode_sensors_(const RegisterMap &regs) {
-  // HVAC mode (respect write cooldown)
-  if ((millis() - this->last_mode_write_) > WRITE_COOLDOWN_MS) {
+  // HVAC mode — only from AWL thermostat holding regs
+  if (this->awl_thermostat() && (millis() - this->last_mode_write_) > WRITE_COOLDOWN_MS) {
     const uint16_t *val_mode = reg_find(regs, registers::HEATING_MODE_READ);
     if (val_mode) {
       uint8_t mode_val = (*val_mode >> 8) & 0x07;
@@ -1618,8 +1644,8 @@ void WaterFurnaceAurora::publish_mode_sensors_(const RegisterMap &regs) {
     }
   }
   
-  // Fan mode (respect write cooldown)
-  if ((millis() - this->last_fan_write_) > WRITE_COOLDOWN_MS) {
+  // Fan mode — only from AWL thermostat holding regs
+  if (this->awl_thermostat() && (millis() - this->last_fan_write_) > WRITE_COOLDOWN_MS) {
     const uint16_t *val_fan = reg_find(regs, registers::FAN_CONFIG);
     if (val_fan) {
       uint16_t config = *val_fan;
@@ -1951,8 +1977,8 @@ void WaterFurnaceAurora::publish_humidity_control_sensors_(const RegisterMap &re
                               (this->active_dehumidify_ && cooling_rv)
                               || (this->has_dehumidifier_ && (this->axb_outputs_ & AXB_OUTPUT_DEHUMIDIFIER) != 0));
   
-  // Humidistat
-  {
+  // Humidistat mode/targets — only when gem would refresh them
+  if (this->has_humidistat_targets()) {
     uint16_t mode_reg = (this->has_iz2_ && this->awl_communicating())
                             ? registers::IZ2_HUMIDISTAT_MODE
                             : registers::HUMIDISTAT_SETTINGS;
@@ -1974,11 +2000,19 @@ void WaterFurnaceAurora::publish_humidity_control_sensors_(const RegisterMap &re
     if (!this->humidity_target_cooldown_active()) {
       const uint16_t *val_targets = reg_find(regs, target_reg);
       if (val_targets) {
-        float hum_target = static_cast<float>((*val_targets >> 8) & 0xFF);
-        if (sensor_value_changed_(this->humidification_target_sensor_, hum_target))
+        uint8_t hum_b = static_cast<uint8_t>((*val_targets >> 8) & 0xFF);
+        uint8_t dehum_b = static_cast<uint8_t>(*val_targets & 0xFF);
+        float hum_target = (hum_b == 0 || hum_b == 0xFF || hum_b < 15 || hum_b > 50)
+                               ? NAN
+                               : static_cast<float>(hum_b);
+        float dehum_target = (dehum_b == 0 || dehum_b == 0xFF || dehum_b < 35 || dehum_b > 65)
+                                 ? NAN
+                                 : static_cast<float>(dehum_b);
+        if (!std::isnan(hum_target) &&
+            sensor_value_changed_(this->humidification_target_sensor_, hum_target))
           this->humidification_target_sensor_->publish_state(hum_target);
-        float dehum_target = static_cast<float>(*val_targets & 0xFF);
-        if (sensor_value_changed_(this->dehumidification_target_sensor_, dehum_target))
+        if (!std::isnan(dehum_target) &&
+            sensor_value_changed_(this->dehumidification_target_sensor_, dehum_target))
           this->dehumidification_target_sensor_->publish_state(dehum_target);
       }
     }

--- a/components/waterfurnace_aurora/waterfurnace_aurora.cpp
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.cpp
@@ -465,6 +465,16 @@ void WaterFurnaceAurora::dump_config() {
     ESP_LOGCONFIG(TAG, "  IZ2 Zones: %d%s", this->num_iz2_zones_,
                   this->iz2_zones_override_ ? " (override)" : "");
   }
+  ESP_LOGCONFIG(TAG, "  Tstat: v%.2f installed=%s awl_thermostat=%s",
+                this->thermostat_version_,
+                this->has_thermostat_ ? "yes" : "no",
+                this->awl_thermostat() ? "yes" : "no");
+  ESP_LOGCONFIG(TAG, "  AWL communicating: %s (thermostat=%s iz2=%s)",
+                this->awl_communicating() ? "yes" : "no",
+                this->awl_thermostat() ? "yes" : "no",
+                this->awl_iz2() ? "yes" : "no");
+  ESP_LOGCONFIG(TAG, "  Humidistat targets: %s (need AWL + humidifier/dehumidifier/VS)",
+                this->has_humidistat_targets() ? "yes" : "no");
   ESP_LOGCONFIG(TAG, "  DIP Switches: fp1=%d fp2=%d rv=%s acc=%d stages=%d lockout=%s dh_rh=%s%s",
                 this->dip_switches_.fp1, this->dip_switches_.fp2,
                 this->dip_switches_.reversing_valve == ReversingValveType::O_TYPE ? "O" : "B",
@@ -654,6 +664,16 @@ void WaterFurnaceAurora::process_setup_detect_response_(const protocol::ParsedRe
     }
   }
   
+  // Thermostat installed — match gem thermostat? => reg 800 != 3
+  {
+    const uint16_t *val = reg_find(result, registers::THERMOSTAT_INSTALLED);
+    if (val) {
+      this->has_thermostat_ = (*val != COMPONENT_NOT_INSTALLED);
+      ESP_LOGD(TAG, "Thermostat reg %d = %d -> %s", registers::THERMOSTAT_INSTALLED, *val,
+               this->has_thermostat_ ? "present" : "absent");
+    }
+  }
+
   // AWL versions
   const uint16_t *val_tver = reg_find(result, registers::THERMOSTAT_VERSION);
   if (val_tver) this->thermostat_version_ = static_cast<float>(*val_tver) / 100.0f;
@@ -809,6 +829,16 @@ void WaterFurnaceAurora::finish_setup_() {
   ESP_LOGI(TAG, "  IZ2: %s%s (v%.2f, %d zones)", this->has_iz2_ ? "yes" : "no",
            this->iz2_override_ ? " (override)" : "",
            this->iz2_version_, this->num_iz2_zones_);
+  ESP_LOGI(TAG, "  Tstat: v%.2f installed=%s awl_thermostat=%s",
+           this->thermostat_version_,
+           this->has_thermostat_ ? "yes" : "no",
+           this->awl_thermostat() ? "yes" : "no");
+  ESP_LOGI(TAG, "  AWL communicating: %s (thermostat=%s iz2=%s)",
+           this->awl_communicating() ? "yes" : "no",
+           this->awl_thermostat() ? "yes" : "no",
+           this->awl_iz2() ? "yes" : "no");
+  ESP_LOGI(TAG, "  Humidistat targets: %s (need AWL + humidifier/dehumidifier/VS)",
+           this->has_humidistat_targets() ? "yes" : "no");
   ESP_LOGI(TAG, "  Blower: %s, Pump: %s, Energy: %d",
            this->blower_type_ == BlowerType::PSC ? "PSC" :
            this->blower_type_ == BlowerType::FIVE_SPEED ? "5-Speed" : "ECM",
@@ -828,6 +858,17 @@ void WaterFurnaceAurora::finish_setup_() {
   this->setup_callbacks_len_ = 0;
   
   this->transition_(State::IDLE);
+}
+
+
+float WaterFurnaceAurora::get_climate_current_temperature_f() const {
+  if (this->awl_thermostat() && !std::isnan(this->ambient_temp_)) {
+    return this->ambient_temp_;
+  }
+  if (!std::isnan(this->entering_air_temp_)) {
+    return this->entering_air_temp_;
+  }
+  return NAN;
 }
 
 // ============================================================================

--- a/components/waterfurnace_aurora/waterfurnace_aurora.h
+++ b/components/waterfurnace_aurora/waterfurnace_aurora.h
@@ -370,6 +370,17 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   bool get_humidifier_auto() const { return this->humidifier_auto_; }
   bool get_dehumidifier_auto() const { return this->dehumidifier_auto_; }
   bool awl_communicating() const { return this->awl_thermostat() || this->awl_iz2(); }
+  bool has_thermostat() const { return this->has_thermostat_; }
+  /// True when system-wide (non-IZ2) AWL thermostat setpoint/mode/fan regs are valid.
+  bool has_awl_thermostat_controls() const { return this->awl_thermostat(); }
+  /// Gem: awl_communicating && (humidifier || dehumidifier || VS drive).
+  bool has_humidistat_targets() const {
+    return this->awl_communicating() &&
+           (this->has_humidifier_ || this->has_dehumidifier_ || this->has_vs_drive_);
+  }
+  /// Ambient if AWL thermostat controls else entering-air cache (may be NAN).
+  float get_climate_current_temperature_f() const;
+  float get_entering_air_temperature() const { return this->entering_air_temp_; }
   bool has_humidifier() const { return this->has_humidifier_; }
   bool has_dehumidifier() const { return this->has_dehumidifier_; }
   const DipSwitchSettings &get_dip_switches() const { return this->dip_switches_; }
@@ -512,7 +523,10 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   
   // AWL version helpers
   bool awl_axb() const { return this->has_axb_ && this->axb_version_ >= 2.0f; }
-  bool awl_thermostat() const { return this->thermostat_version_ >= 3.0f; }
+  // Match gem: thermostat? && version >= 3.0 (reg 800 != 3, reg 801 / 100)
+  bool awl_thermostat() const {
+    return this->has_thermostat_ && this->thermostat_version_ >= 3.0f;
+  }
   bool awl_iz2() const { return this->has_iz2_ && this->iz2_version_ >= 2.0f; }
   bool is_ecm_blower() const { return this->blower_type_ == BlowerType::ECM_208 || this->blower_type_ == BlowerType::ECM_265; }
   bool is_vs_pump() const { return this->pump_type_ == PumpType::VS_PUMP || this->pump_type_ == PumpType::VS_PUMP_26_99 || this->pump_type_ == PumpType::VS_PUMP_UPS26_99; }
@@ -691,6 +705,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   
   // --- Heat pump state ---
   float ambient_temp_{NAN};
+  float entering_air_temp_{NAN};  // Cache for climate current-temp fallback
   float heating_setpoint_{NAN};
   float cooling_setpoint_{NAN};
   float dhw_temp_{NAN};
@@ -704,6 +719,7 @@ class WaterFurnaceAurora : public PollingComponent, public uart::UARTDevice
   bool locked_out_{false};
   bool has_axb_{false};
   bool has_vs_drive_{false};
+  bool has_thermostat_{false};
   bool has_iz2_{false};
   uint8_t num_iz2_zones_{0};
   bool active_dehumidify_{false};

--- a/docs/ENTITIES.md
+++ b/docs/ENTITIES.md
@@ -197,17 +197,20 @@ The climate entity reports the current **action** in real time: Idle, Heating, C
 
 Installs **without** an AWL-compliant communicating thermostat or IntelliZone 2
 (`Tstat` not installed or version < 3.00) still show useful **status** on the
-climate entity:
+climate entity (the entity itself stays **available**):
 
 - **Action** tracks equipment from ABC outputs (heating/cooling/fan/idle)
 - **Current temperature** uses entering/return air when ambient (register 502)
   is not valid for dry-contact
-- **Target temperatures, HVAC mode, fan mode, and humidity targets** are not
-  meaningful from holding registers and are left unavailable; writes are rejected
+- **Target temperatures, HVAC mode, and fan mode** are not meaningful from holding
+  registers and are left unset/unavailable; climate `control()` writes are rejected
+- **Humidity target numbers/selects** and system **fan intermittent** numbers stay
+  unavailable (those registers are not polled without AWL thermostat / humidistat path)
 
 Full setpoint/mode/fan/humidity control requires a communicating AWL thermostat
-or IZ2 zones. Home Assistant may still show climate controls (traits are static);
-values stay unavailable and commands are ignored with a warning in the ESPHome log.
+(version ≥ 3.00, installed) or IZ2 zones. Home Assistant may still show climate
+controls (traits are static); target values stay empty and commands are ignored
+with a warning in the ESPHome log.
 
 ### Mode-Aware Humidity Slider (`target_humidity`)
 

--- a/docs/ENTITIES.md
+++ b/docs/ENTITIES.md
@@ -193,6 +193,22 @@ The component creates climate entities for thermostat control:
 
 The climate entity reports the current **action** in real time: Idle, Heating, Cooling, Drying (active dehumidification), or Fan. The Drying action appears when the VS drive is actively dehumidifying with the reversing valve engaged, or when the AXB dehumidifier relay is active.
 
+### Dry-contact / non-AWL thermostats
+
+Installs **without** an AWL-compliant communicating thermostat or IntelliZone 2
+(`Tstat` not installed or version < 3.00) still show useful **status** on the
+climate entity:
+
+- **Action** tracks equipment from ABC outputs (heating/cooling/fan/idle)
+- **Current temperature** uses entering/return air when ambient (register 502)
+  is not valid for dry-contact
+- **Target temperatures, HVAC mode, fan mode, and humidity targets** are not
+  meaningful from holding registers and are left unavailable; writes are rejected
+
+Full setpoint/mode/fan/humidity control requires a communicating AWL thermostat
+or IZ2 zones. Home Assistant may still show climate controls (traits are static);
+values stay unavailable and commands are ignored with a warning in the ESPHome log.
+
 ### Mode-Aware Humidity Slider (`target_humidity`)
 
 The Aurora has two independent humidity targets (humidification to add moisture, dehumidification to remove it) packed as two bytes in a single 16-bit register. Rather than exposing two separate sliders, the climate entity's single humidity slider **automatically routes to the correct target based on the current HVAC mode**:

--- a/docs/superpowers/plans/2026-07-24-non-awl-climate-gating.md
+++ b/docs/superpowers/plans/2026-07-24-non-awl-climate-gating.md
@@ -1,0 +1,855 @@
+# Non-AWL / Dry-Contact Climate Gating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use subagent-driven-development (recommended) or executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop publishing garbage thermostat/humidistat targets and reject misleading writes on dry-contact (non-AWL) installs, while keeping climate action + current temperature useful via entering-air fallback.
+
+**Architecture:** Hub-wide capability model matching upstream gem v1.6.4 (`awl_thermostat` = installed + version ≥ 3.0; `has_humidistat_targets` = AWL communicating + humidifier/dehumidifier/VS). Poll, publish, and write paths all gate on those helpers. Climate non-IZ2 path becomes status-oriented when AWL thermostat controls are absent.
+
+**Tech Stack:** C++20 ESPHome component, Catch2 unit tests (`tests/test_hub.cpp`), mock UART harness, docs in `docs/ENTITIES.md` + `README.md`.
+
+**Spec:** `docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md`
+
+**Worktree:** `.worktrees/fix-non-awl-climate-gating` on branch `fix/non-awl-climate-gating`
+
+---
+
+## File map
+
+| File | Responsibility |
+| ---- | -------------- |
+| `components/waterfurnace_aurora/waterfurnace_aurora.h` | `has_thermostat_`, fixed `awl_thermostat()`, public helpers, EAT cache + climate temp helper |
+| `components/waterfurnace_aurora/waterfurnace_aurora.cpp` | Detection, poll gates, publish sanitizers, write gates, capability logs |
+| `components/waterfurnace_aurora/climate/aurora_climate.cpp` | Non-IZ2 status-oriented update; EAT fallback via hub helper |
+| `components/waterfurnace_aurora/climate/aurora_climate_utils.h` | Gate humidity target reads on `has_humidistat_targets()` + sanitize `0x00`/`0xFF` |
+| `tests/test_hub.cpp` | Fixture fix (`THERMOSTAT_INSTALLED`), new non-AWL / AWL / humidistat / EAT cases |
+| `docs/ENTITIES.md`, `README.md` | Dry-contact user note |
+
+No protocol or register address changes.
+
+---
+
+### Task 1: Fixture fix + capability helpers (TDD)
+
+**Files:**
+- Modify: `tests/test_hub.cpp`
+- Modify: `components/waterfurnace_aurora/waterfurnace_aurora.h`
+- Modify: `components/waterfurnace_aurora/waterfurnace_aurora.cpp` (detection + logs only in this task)
+
+**Critical fixture note:** `drive_setup` defaults every detect register to `3` (`COMPONENT_NOT_INSTALLED`), then sets `THERMOSTAT_VERSION=300`. Today `awl_thermostat()` is version-only so outdoor-temp tests pass. After the gem-correct fix, version 3.00 + installed=3 must be **false**. Update AWL fixtures so installed ≠ 3.
+
+- [ ] **Step 1: Write failing capability tests**
+
+Add near the end of `tests/test_hub.cpp` (before any final blank lines), and extend `TestableHub` if needed:
+
+```cpp
+// In TestableHub (top of file), add:
+bool test_awl_thermostat() const { return this->awl_thermostat(); }
+bool test_has_humidistat_targets() const { return this->has_humidistat_targets(); }
+bool test_has_thermostat() const { return this->has_thermostat(); }
+void inject_register(uint16_t addr, uint16_t value) {
+  reg_set(this->register_cache_, addr, value);
+}
+void force_publish(const RegisterMap &regs) { this->publish_all_sensors_(); /* see note */ }
+```
+
+Prefer calling **public** APIs once they exist (`has_thermostat()`, `has_awl_thermostat_controls()`, `has_humidistat_targets()`, `awl_communicating()`). Use `TestableHub` only for protected pieces still needed (e.g. driving publish via a public test hook if one is added).
+
+Add helper to customize thermostat detect fields:
+
+```cpp
+// After drive_setup — variant that sets thermostat installed + version explicitly.
+// installed_val: COMPONENT_NOT_INSTALLED (3) = absent; any other status = present (gem).
+// version_raw: register 801 units (300 = v3.00).
+static void drive_setup_thermostat(WaterFurnaceAurora &hub, uint16_t installed_val,
+                                   uint16_t version_raw,
+                                   bool humidifier = false) {
+  hub.setup();
+  hub.loop();
+  hub.mock_get_transmitted();
+  complete_tx(hub, 0);
+  std::vector<uint16_t> id_values(18, 0x2020);
+  hub.mock_receive(make_response_03(id_values));
+  set_millis(50);
+  hub.loop();
+
+  hub.loop();
+  auto tx = hub.mock_get_transmitted();
+  size_t num_detect_regs = (tx.size() - 4) / 2;
+  std::vector<std::pair<uint16_t, uint16_t>> detect_vals;
+  for (size_t i = 0; i < num_detect_regs; i++) {
+    uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+    uint16_t val = 3;
+    if (addr == registers::THERMOSTAT_INSTALLED) val = installed_val;
+    if (addr == registers::THERMOSTAT_VERSION) val = version_raw;
+    if (addr == registers::BLOWER_TYPE) val = 0;
+    if (addr == registers::ENERGY_MONITOR) val = 0;
+    if (addr == registers::PUMP_TYPE) val = 0;
+    // DIP 33: accessory_relay humidifier = bit pattern from parse_dip_switches.
+    // Use a known raw value only if humidifier requested — see registers tests /
+    // parse_dip_switches. If unsure, set has_humidifier via a small TestableHub
+    // setter added for tests, or craft DIP raw that yields AccessoryRelay::HUMIDIFIER.
+    if (addr == registers::DIP_SWITCH_STATUS && humidifier) {
+      // accessory_relay field == HUMIDIFIER (value 1 in low bits per registers.h enum).
+      // Match an existing DIP fixture if one exists; otherwise set raw so
+      // parse_dip_switches().accessory_relay == AccessoryRelay::HUMIDIFIER.
+      val = /* known humidifier DIP raw — verify against parse_dip_switches unit tests */;
+    }
+    if (addr >= 88 && addr <= 91) val = 0x2020;
+    detect_vals.emplace_back(addr, val);
+  }
+  complete_tx(hub, 50);
+  hub.mock_receive(make_response_42(detect_vals));
+  set_millis(100);
+  hub.loop();
+
+  hub.loop();
+  hub.loop();
+  hub.mock_get_transmitted();
+  complete_tx(hub, 100);
+  hub.mock_receive(make_response_42({{3001, 0}, {3322, 0}, {3325, 0}}));
+  set_millis(150);
+  hub.loop();
+}
+```
+
+**Simpler humidifier path for tests:** add a test-only public override on the hub header under existing override pattern, or set via `TestableHub`:
+
+```cpp
+// waterfurnace_aurora.h near other overrides — only if DIP crafting is painful:
+// void set_has_humidifier_for_test(bool v) { this->has_humidifier_ = v; }
+// Prefer real detection in drive_setup_thermostat when DIP raw is known.
+```
+
+Check `tests/test_registers.cpp` / `parse_dip_switches` for a humidifier DIP raw value and use it.
+
+```cpp
+TEST_CASE("awl_thermostat requires installed and version >= 3.0", "[hub][awl][capability]") {
+  SECTION("version 3.00 but not installed") {
+    TestableHub hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, registers::COMPONENT_NOT_INSTALLED, 300);
+    REQUIRE(hub.is_setup_complete());
+    REQUIRE_FALSE(hub.has_thermostat());
+    REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+    REQUIRE_FALSE(hub.awl_communicating());
+  }
+  SECTION("installed + version 3.00") {
+    TestableHub hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, 1 /* installed/ok */, 300);
+    REQUIRE(hub.has_thermostat());
+    REQUIRE(hub.has_awl_thermostat_controls());
+    REQUIRE(hub.awl_communicating());
+  }
+  SECTION("installed + version 0.00 (dry-contact garbage version)") {
+    TestableHub hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, 1, 0);
+    REQUIRE(hub.has_thermostat());  // installed bit true
+    REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+  }
+  SECTION("not installed + version 0") {
+    TestableHub hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, registers::COMPONENT_NOT_INSTALLED, 0);
+    REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+  }
+}
+
+TEST_CASE("has_humidistat_targets matches gem", "[hub][awl][humidistat]") {
+  SECTION("AWL thermostat without humidifier/dehumidifier/VS") {
+    TestableHub hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, 1, 300, /*humidifier=*/false);
+    REQUIRE(hub.has_awl_thermostat_controls());
+    REQUIRE_FALSE(hub.has_humidistat_targets());
+  }
+  SECTION("AWL thermostat with humidifier") {
+    TestableHub hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, 1, 300, /*humidifier=*/true);
+    // If DIP path flaky, after setup: hub.set_has_humidifier_for_test(true);
+    REQUIRE(hub.has_humidistat_targets());
+  }
+  SECTION("non-AWL with humidifier") {
+    TestableHub hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, registers::COMPONENT_NOT_INSTALLED, 0, true);
+    REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+    REQUIRE_FALSE(hub.has_humidistat_targets());
+  }
+}
+```
+
+Also **fix `drive_setup`** so default AWL-style setup marks thermostat installed (preserves existing outdoor-temp and other AWL assumptions):
+
+```cpp
+// Inside drive_setup detect_vals loop, add:
+if (addr == registers::THERMOSTAT_INSTALLED) val = 1;  // present
+if (addr == registers::THERMOSTAT_VERSION) val = 300;
+```
+
+Apply the same `THERMOSTAT_INSTALLED = 1` fix to every custom detect loop in `test_hub.cpp` that sets `THERMOSTAT_VERSION = 300` and intends AWL behavior (full setup flow test, outdoor temp test comments, `drive_setup_with_pump`, etc.). Grep for `THERMOSTAT_VERSION` in the file and update each.
+
+- [ ] **Step 2: Run tests — expect compile failure / link failure for missing APIs**
+
+```bash
+cd tests && make test_hub 2>&1 | tail -40
+```
+
+Expected: missing `has_thermostat`, `has_awl_thermostat_controls`, `has_humidistat_targets`, and/or `COMPONENT_NOT_INSTALLED` access (use `registers::COMPONENT_NOT_INSTALLED` — already in `registers.h`).
+
+- [ ] **Step 3: Implement capability model in header**
+
+In `waterfurnace_aurora.h`:
+
+1. Add public accessors near `awl_communicating()`:
+
+```cpp
+bool has_thermostat() const { return this->has_thermostat_; }
+bool has_awl_thermostat_controls() const { return this->awl_thermostat(); }
+/// Gem: awl_communicating && (humidifier || dehumidifier || VS drive)
+bool has_humidistat_targets() const {
+  return this->awl_communicating() &&
+         (this->has_humidifier_ || this->has_dehumidifier_ || this->has_vs_drive_);
+}
+/// Ambient if AWL thermostat controls else entering-air cache (may be NAN).
+float get_climate_current_temperature_f() const;
+float get_entering_air_temperature() const { return this->entering_air_temp_; }
+```
+
+2. Fix protected helper:
+
+```cpp
+bool awl_thermostat() const {
+  return this->has_thermostat_ && this->thermostat_version_ >= 3.0f;
+}
+```
+
+3. Add members near other hardware flags:
+
+```cpp
+bool has_thermostat_{false};
+float entering_air_temp_{NAN};  // cache for climate fallback; updated in publish
+```
+
+Optional test helper only if DIP crafting fails:
+
+```cpp
+#ifdef UNIT_TEST  // only if test makefile already defines something similar — otherwise skip
+```
+
+Do **not** invent `UNIT_TEST` if the project doesn't use it; use real detection or a minimal public test setter only as last resort.
+
+- [ ] **Step 4: Store `has_thermostat_` during detect**
+
+In `process_setup_detect_response_` after IZ2 detection block (~line 646), before AWL versions:
+
+```cpp
+// Thermostat installed — match gem thermostat? => reg 800 != 3
+{
+  const uint16_t *val = reg_find(result, registers::THERMOSTAT_INSTALLED);
+  if (val) {
+    this->has_thermostat_ = (*val != COMPONENT_NOT_INSTALLED);
+    ESP_LOGD(TAG, "Thermostat reg %d = %d -> %s", registers::THERMOSTAT_INSTALLED, *val,
+             this->has_thermostat_ ? "present" : "absent");
+  }
+}
+```
+
+Implement climate helper in `.cpp`:
+
+```cpp
+float WaterFurnaceAurora::get_climate_current_temperature_f() const {
+  if (this->awl_thermostat() && !std::isnan(this->ambient_temp_)) {
+    return this->ambient_temp_;
+  }
+  if (!std::isnan(this->entering_air_temp_)) {
+    return this->entering_air_temp_;
+  }
+  return NAN;
+}
+```
+
+(EAT cache still always NAN until Task 3 publish path — fine for capability tests.)
+
+- [ ] **Step 5: Capability logging in `finish_setup_` and `dump_config`**
+
+`finish_setup_` after existing IZ2 log:
+
+```cpp
+ESP_LOGI(TAG, "  Tstat: v%.2f installed=%s awl_thermostat=%s",
+         this->thermostat_version_,
+         this->has_thermostat_ ? "yes" : "no",
+         this->awl_thermostat() ? "yes" : "no");
+ESP_LOGI(TAG, "  AWL communicating: %s (thermostat=%s iz2=%s)",
+         this->awl_communicating() ? "yes" : "no",
+         this->awl_thermostat() ? "yes" : "no",
+         this->awl_iz2() ? "yes" : "no");
+ESP_LOGI(TAG, "  Humidistat targets: %s (need AWL + humidifier/dehumidifier/VS)",
+         this->has_humidistat_targets() ? "yes" : "no");
+```
+
+Mirror shorter form in `dump_config()` (include Tstat line — currently missing).
+
+- [ ] **Step 6: Run capability tests**
+
+```bash
+cd tests && make test_hub && ./test_hub "[awl]"
+```
+
+Expected: PASS for new capability cases; fix any broken outdoor-temp case by ensuring its setup marks thermostat installed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add components/waterfurnace_aurora/waterfurnace_aurora.h \
+        components/waterfurnace_aurora/waterfurnace_aurora.cpp \
+        tests/test_hub.cpp \
+        docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md \
+        docs/superpowers/plans/2026-07-24-non-awl-climate-gating.md
+git commit -m "$(cat <<'EOF'
+feat(hub): gate AWL thermostat on installed + version >= 3.0
+
+Match upstream gem thermostat?/awl_thermostat? and add humidistat-target
+capability helpers. Fix test fixtures that assumed version-only AWL.
+EOF
+)"
+```
+
+---
+
+### Task 2: Write gating
+
+**Files:**
+- Modify: `components/waterfurnace_aurora/waterfurnace_aurora.cpp` (control methods)
+- Modify: `tests/test_hub.cpp`
+
+- [ ] **Step 1: Failing write-gate tests**
+
+```cpp
+TEST_CASE("Reject thermostat writes without AWL thermostat", "[hub][awl][write]") {
+  TestableHub hub;
+  set_millis(0);
+  drive_setup_thermostat(hub, registers::COMPONENT_NOT_INSTALLED, 0);
+  REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+
+  size_t writes_before = /* pending write count if exposed, else spy via mock TX after loop */;
+  REQUIRE_FALSE(hub.set_heating_setpoint(70.0f));
+  REQUIRE_FALSE(hub.set_cooling_setpoint(74.0f));
+  REQUIRE_FALSE(hub.set_hvac_mode(HeatingMode::HEAT));
+  REQUIRE_FALSE(hub.set_fan_mode(FanMode::AUTO));
+  REQUIRE_FALSE(hub.set_fan_intermittent_on(5));
+  REQUIRE_FALSE(hub.set_fan_intermittent_off(10));
+  REQUIRE_FALSE(hub.set_humidification_target(40));
+  REQUIRE_FALSE(hub.set_dehumidification_target(50));
+  REQUIRE_FALSE(hub.set_humidifier_mode(true));
+  REQUIRE_FALSE(hub.set_dehumidifier_mode(true));
+
+  // Ensure nothing queued: pump loop and check mock TX has no write frames,
+  // or expose pending_writes_len_ via TestableHub.
+}
+
+TEST_CASE("Allow thermostat writes with AWL thermostat", "[hub][awl][write]") {
+  TestableHub hub;
+  set_millis(0);
+  drive_setup_thermostat(hub, 1, 300);
+  REQUIRE(hub.set_heating_setpoint(70.0f));
+  REQUIRE(hub.set_cooling_setpoint(74.0f));
+  REQUIRE(hub.set_hvac_mode(HeatingMode::HEAT));
+  REQUIRE(hub.set_fan_mode(FanMode::CONTINUOUS));
+  // humidistat targets still false without humidifier — expect false:
+  REQUIRE_FALSE(hub.set_humidification_target(40));
+}
+```
+
+Add to `TestableHub`:
+
+```cpp
+size_t pending_writes() const { return this->pending_writes_len_; }
+```
+
+Assert `pending_writes() == 0` after rejected writes; `> 0` after accepted ones (before process).
+
+- [ ] **Step 2: Run — expect FAIL (writes still accepted)**
+
+```bash
+cd tests && make test_hub && ./test_hub "[awl][write]"
+```
+
+- [ ] **Step 3: Gate write methods**
+
+At the **top** of each method (before range checks), add capability check + WARN:
+
+| Method | Gate |
+| ------ | ---- |
+| `set_heating_setpoint` | `awl_thermostat()` |
+| `set_cooling_setpoint` | `awl_thermostat()` |
+| `set_hvac_mode` | `awl_thermostat()` |
+| `set_fan_mode` | `awl_thermostat()` |
+| `set_fan_intermittent_on` | `awl_thermostat()` |
+| `set_fan_intermittent_off` | `awl_thermostat()` |
+| `set_humidification_target` | `has_humidistat_targets()` |
+| `set_dehumidification_target` | `has_humidistat_targets()` |
+| `set_humidifier_mode` | `has_humidistat_targets()` |
+| `set_dehumidifier_mode` | `has_humidistat_targets()` |
+
+Example:
+
+```cpp
+bool WaterFurnaceAurora::set_heating_setpoint(float temp) {
+  if (!this->awl_thermostat()) {
+    ESP_LOGW(TAG,
+             "Ignoring heating setpoint write — no AWL communicating thermostat "
+             "(dry-contact / Tstat v%.2f)",
+             this->thermostat_version_);
+    return false;
+  }
+  if (temp < 40.0f || temp > 90.0f) {
+    ...
+  }
+  ...
+}
+```
+
+Do **not** gate IZ2 zone setters.
+
+- [ ] **Step 4: Run write tests — PASS**
+
+```bash
+cd tests && make test_hub && ./test_hub "[awl]"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/waterfurnace_aurora/waterfurnace_aurora.cpp tests/test_hub.cpp
+git commit -m "$(cat <<'EOF'
+fix(hub): reject AWL thermostat and humidistat writes without capability
+
+Dry-contact installs must not queue setpoint/mode/fan/humidistat target
+writes that the wall tstat owns.
+EOF
+)"
+```
+
+---
+
+### Task 3: Poll + publish gating and sanitization
+
+**Files:**
+- Modify: `components/waterfurnace_aurora/waterfurnace_aurora.cpp` (`build_poll_addresses_`, `publish_temperature_sensors_`, `publish_mode_sensors_`, `publish_humidity_control_sensors_`)
+- Modify: `tests/test_hub.cpp`
+
+- [ ] **Step 1: Failing publish/sanitize tests**
+
+Need a way to run one publish cycle with injected register values after setup. Pattern used elsewhere: start poll, feed 0x42 response, or call a test hook.
+
+Add to `TestableHub` if no cleaner path:
+
+```cpp
+void publish_from(const std::vector<std::pair<uint16_t, uint16_t>> &pairs) {
+  RegisterMap regs;
+  for (const auto &p : pairs) {
+    reg_set(regs, p.first, p.second);
+    reg_set(this->register_cache_, p.first, p.second);
+  }
+  this->publish_all_sensors_();  // uses register_cache_ — verify publish_all reads cache
+}
+```
+
+**Check** `publish_all_sensors_()` — it may take `register_cache_` internally or last poll map. Read the function and match existing sensor tests (`Entering air temperature suppresses zero values`) which feed a poll response via mock UART. Prefer that proven pattern:
+
+```cpp
+// After drive_setup_thermostat(non-AWL):
+// trigger update()/loop poll, feed response with HEATING_SETPOINT=1260, COOLING=600,
+// HUMIDISTAT_TARGETS=0xFFFF, AMBIENT whatever, ENTERING_AIR=740 (74.0F)
+// then REQUIRE isnan(get_heating_setpoint()) etc.
+```
+
+Study `TEST_CASE("Entering air temperature suppresses zero values")` and clone structure.
+
+```cpp
+TEST_CASE("Non-AWL publish ignores garbage setpoints and modes", "[hub][awl][publish]") {
+  // non-AWL setup
+  // poll response includes:
+  //   HEATING_SETPOINT = 1260 (126.0 F), COOLING_SETPOINT = 600 (60.0 F)
+  //   HEATING_MODE_READ packed heat, FAN_CONFIG, AMBIENT_TEMP garbage
+  //   ENTERING_AIR = 740, SYSTEM_OUTPUTS with compressor+heat bits
+  //   HUMIDISTAT_TARGETS = 0xFFFF
+  REQUIRE(std::isnan(hub.get_heating_setpoint()));
+  REQUIRE(std::isnan(hub.get_cooling_setpoint()));
+  REQUIRE(std::isnan(hub.get_ambient_temperature()));
+  // EAT cache should still update:
+  REQUIRE(hub.get_entering_air_temperature() == Approx(74.0f));
+  REQUIRE(hub.get_climate_current_temperature_f() == Approx(74.0f));
+}
+
+TEST_CASE("AWL publish accepts valid setpoints and rejects out-of-range", "[hub][awl][publish]") {
+  // AWL setup, heating 700 (70F), cooling 740 (74F) → caches update
+  // then heating 1260 → heating cache becomes NAN (or stays/forces NAN)
+}
+
+TEST_CASE("has_humidistat_targets gates humidistat target publish", "[hub][awl][publish]") {
+  // AWL without humidifier: even if targets in response, sensors/caches don't take 255
+  // non-AWL + humidifier: same
+}
+```
+
+For RH: if value 255 present while somehow cached, force NAN when `> 100`.
+
+- [ ] **Step 2: Run — FAIL on garbage still accepted**
+
+```bash
+cd tests && make test_hub && ./test_hub "[awl][publish]"
+```
+
+- [ ] **Step 3: Poll gating in `build_poll_addresses_`**
+
+Replace unconditional ambient/setpoint/mode/fan adds:
+
+```cpp
+// Was always:
+// add AMBIENT_TEMP, HEATING_SETPOINT, COOLING_SETPOINT, HEATING_MODE_READ, FAN_CONFIG
+
+if (this->awl_thermostat()) {
+  this->add_poll_addr_(registers::AMBIENT_TEMP);
+  this->add_poll_addr_(registers::HEATING_SETPOINT);
+  this->add_poll_addr_(registers::COOLING_SETPOINT);
+  this->add_poll_addr_(registers::HEATING_MODE_READ);
+  this->add_poll_addr_(registers::FAN_CONFIG);
+}
+```
+
+Keep EAT (567/740) unconditional as today.
+
+Replace humidistat medium-tier block:
+
+```cpp
+if (this->has_humidistat_targets()) {
+  if (this->has_iz2_ && this->awl_communicating()) {
+    this->add_poll_addr_(registers::IZ2_HUMIDISTAT_SETTINGS);
+    this->add_poll_addr_(registers::IZ2_HUMIDISTAT_MODE);
+    this->add_poll_addr_(registers::IZ2_HUMIDISTAT_TARGETS);
+  } else {
+    this->add_poll_addr_(registers::HUMIDISTAT_SETTINGS);
+    this->add_poll_addr_(registers::HUMIDISTAT_TARGETS);
+  }
+}
+```
+
+Keep `RELATIVE_HUMIDITY` / `OUTDOOR_TEMP` on `awl_communicating()` as today.
+
+- [ ] **Step 4: Publish gating + sanitizers**
+
+**Ambient** (`publish_temperature_sensors_`):
+
+```cpp
+if (this->awl_thermostat()) {
+  const uint16_t *val_amb = reg_find(regs, registers::AMBIENT_TEMP);
+  if (val_amb) {
+    this->ambient_temp_ = to_signed_tenths(*val_amb);
+    ...
+  }
+} else {
+  this->ambient_temp_ = NAN;
+  // do not publish ambient sensor from 502
+}
+```
+
+**Entering air** — also cache:
+
+```cpp
+if (val && *val != 0) {
+  float fval = to_signed_tenths(*val);
+  this->entering_air_temp_ = fval;
+  ...
+} 
+// optional: if zero/missing, leave prior or set NAN — prefer set NAN when zero suppressed
+```
+
+**Setpoints** (inside cooldown window block):
+
+```cpp
+if (!this->awl_thermostat()) {
+  this->heating_setpoint_ = NAN;
+  this->cooling_setpoint_ = NAN;
+} else if ((millis() - this->last_setpoint_write_) > WRITE_COOLDOWN_MS) {
+  const uint16_t *val_hsp = reg_find(regs, registers::HEATING_SETPOINT);
+  if (val_hsp) {
+    float v = to_tenths(*val_hsp);
+    if (std::isnan(v) || v < 40.0f || v > 90.0f) {
+      this->heating_setpoint_ = NAN;
+    } else {
+      this->heating_setpoint_ = v;
+      if (sensor_value_changed_(...)) publish...
+    }
+  }
+  // cooling: valid 54–99 inclusive
+  ...
+}
+```
+
+When forcing NAN after previously published garbage, still call `publish_state(NAN)` if sensor configured and value changed (so HA clears bad state).
+
+**RH:**
+
+```cpp
+if (val_rh) {
+  float rh = static_cast<float>(*val_rh);
+  if (rh > 100.0f) rh = NAN;  // includes 255
+  this->relative_humidity_ = rh;
+  ...
+}
+```
+
+**Mode/fan** (`publish_mode_sensors_`): only update `hvac_mode_` / `fan_mode_` and text sensors when `awl_thermostat()`. When false, do not treat 12006/12005 as device truth (leave defaults; do not publish bogus mode strings from those regs).
+
+**Humidistat targets** (`publish_humidity_control_sensors_`): wrap mode+target parsing in `if (this->has_humidistat_targets())`. Sanitize bytes:
+
+```cpp
+auto sane_hum = [](uint8_t b) -> float {
+  if (b == 0 || b == 0xFF || b < 15 || b > 50) return NAN;
+  return static_cast<float>(b);
+};
+auto sane_dehum = [](uint8_t b) -> float {
+  if (b == 0 || b == 0xFF || b < 35 || b > 65) return NAN;
+  return static_cast<float>(b);
+};
+```
+
+Only publish sensor when non-NAN. Running binary sensors stay as today (no AWL gate).
+
+- [ ] **Step 5: Run publish tests + full hub suite**
+
+```bash
+cd tests && make test_hub && ./test_hub
+```
+
+Expected: all PASS. Fix any test that assumed non-AWL setup still polled setpoints.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/waterfurnace_aurora/waterfurnace_aurora.cpp tests/test_hub.cpp
+git commit -m "$(cat <<'EOF'
+fix(hub): gate poll/publish of thermostat and humidistat targets
+
+Skip non-AWL setpoint/mode/ambient/humidistat registers, sanitize ranges,
+cache entering air for climate fallback, and clear garbage to NAN.
+EOF
+)"
+```
+
+---
+
+### Task 4: Climate entity status-oriented path
+
+**Files:**
+- Modify: `components/waterfurnace_aurora/climate/aurora_climate.cpp`
+- Modify: `components/waterfurnace_aurora/climate/aurora_climate_utils.h`
+- Modify: `tests/test_hub.cpp` and/or `tests/test_climate_math.cpp` only if harness can drive climate; otherwise hub helper coverage from Task 3 is enough and climate changes are thin.
+
+- [ ] **Step 1: Update `read_mode_humidity_target`**
+
+```cpp
+inline float read_mode_humidity_target(WaterFurnaceAurora *hub, climate::ClimateMode mode) {
+  if (hub == nullptr || !hub->has_humidistat_targets()) return NAN;
+  ...
+  uint8_t byte = ...;
+  if (byte == 0 || byte == 0xFF) return NAN;
+  // optional range check per mode
+  return static_cast<float>(byte);
+}
+```
+
+- [ ] **Step 2: Non-IZ2 `update_state_` branch**
+
+Replace ambient-only current temp:
+
+```cpp
+float temp_f = this->parent_->get_climate_current_temperature_f();
+if (!std::isnan(temp_f)) {
+  float raw_c = fahrenheit_to_celsius(temp_f);
+  this->current_temperature = apply_ema(raw_c, this->temp_ema_, EMA_ALPHA);
+}
+```
+
+When `!this->parent_->has_awl_thermostat_controls()`:
+
+```cpp
+// Force unavailable targets so HA does not keep 126/60 or defaults forever
+this->target_temperature_low = NAN;
+this->target_temperature_high = NAN;
+this->target_humidity = NAN;
+// Do NOT update mode/preset/fan_mode from hub AWL regs
+// Action block stays unchanged (outputs-based)
+```
+
+When `has_awl_thermostat_controls()`: keep existing setpoint/mode/fan update logic.
+
+Shared humidity block already uses `read_mode_humidity_target` — with gate, non-AWL stays NAN. For non-AWL explicitly set `target_humidity = NAN` each update so stale optimistic control() values clear... Spec: control no-ops when hub returns false; still set NAN on update when gate false.
+
+- [ ] **Step 3: Optional climate dump_config note**
+
+```cpp
+if (this->parent_->is_setup_complete() && !this->is_iz2_mode_()) {
+  ESP_LOGCONFIG(TAG, "  AWL thermostat controls: %s",
+                this->parent_->has_awl_thermostat_controls() ? "yes" : "no (status-only)");
+}
+```
+
+- [ ] **Step 4: Build tests (climate compiles via hub only; no separate climate binary)**
+
+```bash
+cd tests && make test
+```
+
+If climate is not in unit test binary, ensure hub helper tests cover EAT fallback; manually review climate diff for `this->` style.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/waterfurnace_aurora/climate/aurora_climate.cpp \
+        components/waterfurnace_aurora/climate/aurora_climate_utils.h \
+        tests/test_hub.cpp
+git commit -m "$(cat <<'EOF'
+fix(climate): status-only non-AWL path with entering-air fallback
+
+Keep action and current temperature useful on dry-contact; clear bogus
+targets/modes and ignore humidity targets without AWL humidistat path.
+EOF
+)"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `docs/ENTITIES.md`
+- Modify: `README.md` (one bullet if climate features listed)
+
+- [ ] **Step 1: ENTITIES.md** — under Climate Entities, after the main/IZ2 bullets:
+
+```markdown
+### Dry-contact / non-AWL thermostats
+
+Installs **without** an AWL-compliant communicating thermostat or IntelliZone 2
+(`Tstat` not installed or version &lt; 3.00) still show useful **status** on the
+climate entity:
+
+- **Action** tracks equipment from ABC outputs (heating/cooling/fan/idle)
+- **Current temperature** uses entering/return air when ambient (register 502)
+  is not valid for dry-contact
+- **Target temperatures, HVAC mode, fan mode, and humidity targets** are not
+  meaningful from holding registers and are left unavailable; writes are rejected
+
+Full setpoint/mode/fan/humidity control requires a communicating AWL thermostat
+or IZ2 zones. HA may still show climate controls (traits are static); values
+stay unavailable and commands are ignored with a warning in the ESPHome log.
+```
+
+- [ ] **Step 2: README.md** — short bullet near climate/IZ2 notes:
+
+```markdown
+- Dry-contact (non-AWL) wall thermostats: climate is status-oriented (action +
+  return-air temp); setpoints/mode writes require AWL thermostat or IZ2
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/ENTITIES.md README.md
+git commit -m "$(cat <<'EOF'
+docs: note dry-contact / non-AWL climate behavior
+
+Document status-only climate UX and write rejection without AWL/IZ2.
+EOF
+)"
+```
+
+---
+
+### Task 6: Full verification + mark spec acceptance
+
+- [ ] **Step 1: Full unit suite**
+
+```bash
+cd tests && make clean && make test
+```
+
+Expected: All tests passed (protocol, registers, hub, climate_math).
+
+- [ ] **Step 2: Spec acceptance checklist** (tick in spec or PR body)
+
+- Dry-contact: no garbage setpoints; climate targets NAN; humidity not 255  
+- Dry-contact: `set_*` return false; no write frames  
+- Dry-contact: action still works; current temp from EAT  
+- AWL: setpoints/mode/fan/humidity still work when capable  
+- `awl_thermostat()` = installed + version ≥ 3.0  
+- `make test` green  
+- ENTITIES/README note present  
+
+- [ ] **Step 3: Update design spec status line**
+
+```markdown
+**Status:** Implemented (branch `fix/non-awl-climate-gating`)
+```
+
+Commit if desired with docs.
+
+- [ ] **Step 4: Open PR** (from worktree)
+
+```bash
+git push -u origin HEAD
+gh pr create --title "fix: non-AWL / dry-contact climate and setpoint gating" --body "$(cat <<'EOF'
+## Summary
+- Gate thermostat ambient/setpoints/mode/fan and humidistat targets on hub AWL capability (gem-compatible)
+- Reject misleading writes on dry-contact installs
+- Climate status-oriented path with entering-air current temp fallback
+- Docs for dry-contact UX
+
+Closes / relates to field report follow-up (GitHub #28 dry-contact targets).
+
+## Spec
+`docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md`
+
+## Test plan
+- [x] `cd tests && make test`
+- [ ] Field: dry-contact unit — no 126/60/255; action + EAT temp
+- [ ] Field: AWL thermostat — regression on setpoints/mode/fan/humidity
+EOF
+)"
+```
+
+---
+
+## Self-review (plan vs spec)
+
+| Spec section | Task |
+| ------------ | ---- |
+| 5 Capability model | Task 1 |
+| 6 Poll gating | Task 3 |
+| 7 Publish gating | Task 3 |
+| 8 Write gating | Task 2 |
+| 9 Climate behavior | Task 4 |
+| 10 Downstream entities | Inherited via hub (Tasks 2–3); no YAML |
+| 11 Detection logs | Task 1 |
+| 12 Unit tests | Tasks 1–4 |
+| 13 Docs | Task 5 |
+| 17 Acceptance | Task 6 |
+
+No protocol changes. IZ2 zone control path unchanged except shared humidistat helpers.
+
+---
+
+## Execution notes for agents
+
+1. Work only in `.worktrees/fix-non-awl-climate-gating`.
+2. TDD: red → green → commit per task.
+3. Always `this->` on members; no heap in `loop()`; no `mark_failed()` for this feature.
+4. After Task 1 fixture fix, re-run **entire** `./test_hub` — outdoor temp and any AWL-assuming case must still pass.
+5. Prefer public hub APIs for climate; keep climate thin.
+6. Do not strip climate traits dynamically (spec non-goal).

--- a/docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md
+++ b/docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md
@@ -1,7 +1,7 @@
 # Non-AWL / Dry-Contact Climate & Setpoint Gating — Design Spec
 
 **Date:** 2026-07-24  
-**Status:** Approved — implementation on `fix/non-awl-climate-gating`  
+**Status:** Implemented (branch `fix/non-awl-climate-gating`)  
 **Related:** GitHub #28 follow-up (daviss57 dry-contact climate targets); upstream gem `waterfurnace_aurora` **v1.6.4** at `../waterfurnace_aurora`  
 **Decisions locked:** Scope = hub-wide (A); Climate UX = status-oriented (A); Writes = reject without AWL (A); Ambient = gate 502 + EAT fallback (B)
 
@@ -418,13 +418,13 @@ No protocol/register address changes.
 
 ## 17. Acceptance criteria
 
-- [ ] Dry-contact fixture: no heating/cooling setpoint sensor state from garbage regs; climate targets NAN; humidity target not 255
-- [ ] Dry-contact: `set_*` thermostat/humidistat target APIs return false; no write frames queued
-- [ ] Dry-contact: climate `action` still tracks equipment; `current_temperature` from EAT when ambient gated off
-- [ ] AWL thermostat fixture: setpoints, mode, fan, humidity targets still poll/publish/write
-- [ ] `awl_thermostat()` requires installed + version ≥ 3.0
-- [ ] `cd tests && make test` green
-- [ ] ENTITIES/README note present
+- [x] Dry-contact fixture: no heating/cooling setpoint sensor state from garbage regs; climate targets NAN; humidity target not 255
+- [x] Dry-contact: `set_*` thermostat/humidistat target APIs return false; no write frames queued
+- [x] Dry-contact: climate `action` still tracks equipment; `current_temperature` from EAT when ambient gated off
+- [x] AWL thermostat fixture: setpoints, mode, fan, humidity targets still poll/publish/write
+- [x] `awl_thermostat()` requires installed + version ≥ 3.0
+- [x] `cd tests && make test` green
+- [x] ENTITIES/README note present
 
 ---
 

--- a/docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md
+++ b/docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md
@@ -1,7 +1,7 @@
 # Non-AWL / Dry-Contact Climate & Setpoint Gating — Design Spec
 
 **Date:** 2026-07-24  
-**Status:** Draft (awaiting approval)  
+**Status:** Approved — implementation on `fix/non-awl-climate-gating`  
 **Related:** GitHub #28 follow-up (daviss57 dry-contact climate targets); upstream gem `waterfurnace_aurora` **v1.6.4** at `../waterfurnace_aurora`  
 **Decisions locked:** Scope = hub-wide (A); Climate UX = status-oriented (A); Writes = reject without AWL (A); Ambient = gate 502 + EAT fallback (B)
 

--- a/docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md
+++ b/docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md
@@ -279,7 +279,7 @@ Applies to the **non-IZ2 thermostat path** (`!is_iz2_mode_()`). IZ2 path unchang
 | Climate field                          | Behavior                                                          |
 | -------------------------------------- | ----------------------------------------------------------------- |
 | `target_temperature_low/high`          | Do not update; ensure `NAN` so HA does not show 126/60            |
-| `target_humidity`                      | Do not update; `NAN`                                              |
+| `target_humidity`                      | Do not update from humidistat regs. **Do not publish `NAN`** — HA `EsphomeClimateEntity.target_humidity` does `round(value)` without `isfinite()`, so `NaN` raises and the climate entity stays unavailable. Leave default/prior finite value until a real target exists. |
 | `mode` / `preset`                      | Do **not** update from hub AWL mode regs                          |
 | `fan_mode`                             | Do **not** update from hub fan regs                               |
 | `action`                               | Still updated from outputs                                        |

--- a/docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md
+++ b/docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md
@@ -1,0 +1,439 @@
+# Non-AWL / Dry-Contact Climate & Setpoint Gating — Design Spec
+
+**Date:** 2026-07-24  
+**Status:** Draft (awaiting approval)  
+**Related:** GitHub #28 follow-up (daviss57 dry-contact climate targets); upstream gem `waterfurnace_aurora` **v1.6.4** at `../waterfurnace_aurora`  
+**Decisions locked:** Scope = hub-wide (A); Climate UX = status-oriented (A); Writes = reject without AWL (A); Ambient = gate 502 + EAT fallback (B)
+
+---
+
+## 1. Problem
+
+On installs **without** an AWL-compliant communicating thermostat or IZ2 (`Tstat: v0.00`, dry-contact wall tstat), the ABC still returns _something_ for thermostat/humidistat holding registers. Those values are not meaningful setpoints.
+
+Field report (5-Series NSKW08H63ACCSSH, no AXB/VS/IZ2):
+
+| Field                        | Observed                        | Meaning                            |
+| ---------------------------- | ------------------------------- | ---------------------------------- |
+| Climate targets              | Low 52.22 °C / High 15.56 °C    | 126 °F / 60 °F garbage; Low > High |
+| Humidity setpoints           | 255                             | `0xFF` unpopulated byte            |
+| Mode / action / live sensors | HEAT / HEATING / sensible temps | Bus and outputs path OK            |
+
+RS-485 framing is fixed (#31/#33). This is **register semantics / UX**, not communications.
+
+---
+
+## 2. Upstream gem contract (v1.6.4 — verified)
+
+Source: `../waterfurnace_aurora/lib/aurora/` (identical gating to prior `ccutre_wf` checkout for these paths).
+
+### Capability flags
+
+```ruby
+def awl_thermostat?
+  thermostat? && thermostat_version >= 3.0   # reg 800 != 3, reg 801 / 100
+end
+
+def awl_iz2?
+  iz2? && iz2_version >= 2.0
+end
+
+def awl_communicating?
+  awl_thermostat? || awl_iz2?
+end
+```
+
+### What is read when
+
+| Data                                                  | Registers                                  | Gate                                                                  |
+| ----------------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------- |
+| Ambient, heat/cool setpoints, fan config, target mode | 502, 745–746, 12005–12006                  | **`awl_thermostat?` only** (`Thermostat#registers_to_read`)           |
+| Relative humidity, outdoor temp                       | 741–742                                    | **`awl_communicating?`** (`ABCClient` + humidistat)                   |
+| Humidistat settings/targets                           | 12309–12310 or IZ2 equiv                   | **`awl_communicating?` AND** (humidifier OR dehumidifier OR VS drive) |
+| Entering air, outputs, status, FP, etc.               | 30–31, 567/740, …                          | Always (core poll)                                                    |
+| Call / “current mode” on thermostat object            | Derived from **inputs** Y1/Y2/O/G (reg 31) | Always refreshed; **not** from 12006 when non-AWL                     |
+
+### Humidistat object lifetime
+
+```ruby
+@humidistat = nil unless humidifier? || dehumidifier? || awl_communicating?
+```
+
+Running flags still come from outputs/relays when the object exists; **targets are not refreshed** unless `awl_communicating?`.
+
+### Writes in the gem
+
+Setter methods (`heating_target_temperature=`, `target_mode=`, etc.) do **not** re-check AWL; the gem relies on not exposing UI when the component has no data. **Our ESPHome entities are always YAML-configured**, so we must **reject writes in the hub** when capability is absent (stricter than gem setters, correct for HA).
+
+### IZ2
+
+Per-zone ambient/setpoints/mode live on IZ2 registers and require `awl_iz2?` / zone setup. Unchanged by this work except shared humidistat gating already uses `awl_communicating()`.
+
+---
+
+## 3. Goals
+
+1. **No bogus thermostat/humidistat targets** on non-AWL installs (climate, sensors, numbers, selects).
+2. **Hub-wide gating** — one capability model; all entities inherit.
+3. **Reject misleading writes** when the wall tstat owns dry-contact calls.
+4. **Keep useful status** on dry-contact: action from outputs, current temperature via ambient **or** entering-air fallback, humidifier/dehumidifier running when hardware says so.
+5. **Defensive publish filters** even when AWL is present (range / `0xFF`).
+6. **Fix `awl_thermostat()`** to match gem (`thermostat installed && version >= 3.0`).
+7. Unit tests + short docs note for dry-contact behavior.
+
+## 4. Non-goals
+
+- Turning HA into a full replacement thermostat over dry-contact (driving Y1/Y2).
+- Dynamic climate **traits** stripping (HA caches `ListEntitiesClimateResponse`; fragile).
+- Changing IZ2 zone math or VS-only paths beyond shared humidistat gates.
+- Inferring a synthetic HA `climate.mode` from Y1/Y2 (optional later; see Open follow-ups).
+- Removing YAML entities at codegen time based on runtime detection (detection is post-setup).
+
+---
+
+## 5. Capability model (hub)
+
+### 5.1 Store thermostat installed
+
+During hardware detection (already reads `THERMOSTAT_INSTALLED` = 800):
+
+```cpp
+// Match gem: thermostat? => holding_registers[800] != 3
+this->has_thermostat_ = (*val != COMPONENT_NOT_INSTALLED);
+```
+
+Log in detection dump alongside Tstat version.
+
+### 5.2 Fix helpers
+
+```cpp
+bool awl_thermostat() const {
+  return this->has_thermostat_ && this->thermostat_version_ >= 3.0f;
+}
+bool awl_iz2() const {
+  return this->has_iz2_ && this->iz2_version_ >= 2.0f;
+}
+bool awl_communicating() const {
+  return this->awl_thermostat() || this->awl_iz2();
+}
+```
+
+Optional convenience (documentation / call sites):
+
+```cpp
+/// True when system-wide (non-IZ2) AWL thermostat setpoint/mode/fan regs are valid.
+bool has_awl_thermostat_controls() const { return this->awl_thermostat(); }
+
+/// True when humidistat *target/mode registers* should be polled/published.
+/// Gem: awl_communicating && (humidifier || dehumidifier || VS).
+bool has_humidistat_targets() const {
+  return this->awl_communicating() &&
+         (this->has_humidifier_ || this->has_dehumidifier_ || this->has_vs_drive_);
+}
+```
+
+Expose read-only accessors if tests/climate need them (`has_thermostat()`, existing version getters).
+
+---
+
+## 6. Poll gating (`build_poll_addresses_`)
+
+### 6.1 Thermostat block (today always on fast tier)
+
+| Register                    | Poll when          |
+| --------------------------- | ------------------ |
+| `AMBIENT_TEMP` (502)        | `awl_thermostat()` |
+| `HEATING_SETPOINT` (745)    | `awl_thermostat()` |
+| `COOLING_SETPOINT` (746)    | `awl_thermostat()` |
+| `HEATING_MODE_READ` (12006) | `awl_thermostat()` |
+| `FAN_CONFIG` (12005)        | `awl_thermostat()` |
+
+Entering air (567/740) stays on the unconditional core list (supports climate temp fallback).
+
+### 6.2 Humidity / outdoor (already partly correct)
+
+| Register                  | Poll when                        |
+| ------------------------- | -------------------------------- |
+| `RELATIVE_HUMIDITY` (741) | `awl_communicating()` — **keep** |
+| `OUTDOOR_TEMP` (742)      | `awl_communicating()` — **keep** |
+
+### 6.3 Humidistat settings/targets (medium tier today)
+
+Replace unconditional non-IZ2 poll with:
+
+```
+if (has_humidistat_targets()) {
+  if (has_iz2_ && awl_communicating())
+    poll IZ2_HUMIDISTAT_*;
+  else
+    poll HUMIDISTAT_SETTINGS + HUMIDISTAT_TARGETS;
+}
+```
+
+Do **not** poll target regs when only a physical humidifier exists but there is no AWL path (gem agrees: `registers_to_read` empty without `awl_communicating?`).
+
+### 6.4 Fan intermittent numbers
+
+System-wide intermittent on/off numbers read `FAN_CONFIG`. When `FAN_CONFIG` is not polled, cache misses → NAN → numbers simply do not update (acceptable). Zone IZ2 paths unchanged.
+
+---
+
+## 7. Publish gating & sanitization
+
+### 7.1 Setpoints
+
+Only update `heating_setpoint_` / `cooling_setpoint_` (and sensors) when `awl_thermostat()` **and** value passes range:
+
+| Value   | Valid range (°F) |
+| ------- | ---------------- |
+| Heating | 40–90 inclusive  |
+| Cooling | 54–99 inclusive  |
+
+Out of range or missing → leave cache as `NAN` (or set to `NAN` if previously garbage — prefer **force NAN when gate fails** so stale boot values cannot linger).
+
+`to_tenths()` already maps `0x270F` → NAN; keep that.
+
+### 7.2 HVAC mode / fan mode text sensors + caches
+
+Only update `hvac_mode_` / `fan_mode_` from 12006/12005 when `awl_thermostat()`.
+
+When gate is false: do **not** publish mode/fan text sensors from those regs; leave enums at defaults without claiming device truth. (Climate section defines entity behavior.)
+
+### 7.3 Ambient
+
+Only update `ambient_temp_` from 502 when `awl_thermostat()` and conversion is non-NAN.
+
+### 7.4 Humidistat targets / auto modes
+
+Only parse/publish humidification/dehumidification targets and auto/manual mode caches when `has_humidistat_targets()`.
+
+Per-byte sanitization when publishing:
+
+| Byte                                               | Valid                |
+| -------------------------------------------------- | -------------------- |
+| Humidification target                              | 15–50                |
+| Dehumidification target                            | 35–65                |
+| Either byte `0xFF` or `0x00` if treated as invalid | → NAN / skip publish |
+
+(Confirm `0x00`: treat **0** as invalid for targets; gem ranges start at 15/35.)
+
+Humidifier/dehumidifier **running** binary sensors stay gated only on DIP/hardware + outputs (no AWL required).
+
+### 7.5 Relative humidity cache
+
+Already polled only when `awl_communicating()`. Additionally ignore implausible values if desired (e.g. `> 100` or `255`) → NAN. Cheap safety.
+
+---
+
+## 8. Write gating (hub control API)
+
+All of the following return `false` + `ESP_LOGW` when the gate fails **before** queueing a write:
+
+| Method                                      | Gate                       |
+| ------------------------------------------- | -------------------------- |
+| `set_heating_setpoint`                      | `awl_thermostat()`         |
+| `set_cooling_setpoint`                      | `awl_thermostat()`         |
+| `set_hvac_mode`                             | `awl_thermostat()`         |
+| `set_fan_mode`                              | `awl_thermostat()`         |
+| `set_fan_intermittent_on/off` (system-wide) | `awl_thermostat()`         |
+| `set_humidification_target`                 | `has_humidistat_targets()` |
+| `set_dehumidification_target`               | `has_humidistat_targets()` |
+| `set_humidifier_mode`                       | `has_humidistat_targets()` |
+| `set_dehumidifier_mode`                     | `has_humidistat_targets()` |
+
+IZ2 zone setters remain gated on IZ2 presence/zone validity as today (they are the AWL-IZ2 control path).
+
+Keep existing numeric range checks **after** capability checks.
+
+Log message pattern:
+
+```text
+Ignoring heating setpoint write — no AWL communicating thermostat (dry-contact / Tstat vX.XX)
+```
+
+---
+
+## 9. Climate entity behavior (status-oriented)
+
+Applies to the **non-IZ2 thermostat path** (`!is_iz2_mode_()`). IZ2 path unchanged except humidistat helpers already key off `awl_communicating()`.
+
+### 9.1 Always (both AWL and dry-contact)
+
+- **Action** from system outputs / lockout / dehumidify — unchanged.
+- **Current temperature:**
+  1. If `awl_thermostat()` and ambient valid → use ambient (°F → °C, existing EMA).
+  2. Else if entering-air temperature valid (hub already suppresses raw 0) → use EAT as current temp with same EMA path.
+  3. Else leave current temperature unset (`NAN`).
+- **Current humidity:** only if RH cache non-NAN (implies AWL communicating + sane value).
+
+### 9.2 When `awl_thermostat()` is true
+
+- Publish `target_temperature_low/high` from heating/cooling setpoints (already sanitized).
+- Publish `mode` / `preset` from hub HVAC mode.
+- Publish `fan_mode` / custom intermittent from hub fan mode.
+- Publish `target_humidity` via existing mode-aware helper when humidistat targets exist.
+- `control()` writes flow to hub (hub still range-checks).
+
+### 9.3 When `awl_thermostat()` is false (dry-contact)
+
+| Climate field                          | Behavior                                                          |
+| -------------------------------------- | ----------------------------------------------------------------- |
+| `target_temperature_low/high`          | Do not update; ensure `NAN` so HA does not show 126/60            |
+| `target_humidity`                      | Do not update; `NAN`                                              |
+| `mode` / `preset`                      | Do **not** update from hub AWL mode regs                          |
+| `fan_mode`                             | Do **not** update from hub fan regs                               |
+| `action`                               | Still updated from outputs                                        |
+| `current_temperature`                  | Ambient if AWL else EAT fallback                                  |
+| `control()` mode/fan/setpoint/humidity | No-op after hub returns false; climate may log at DEBUG/WARN once |
+
+**Traits:** leave static (still advertise two-point targets, modes, humidity). HA may show controls; values unavailable and writes rejected. Document this. Dynamic traits are a non-goal.
+
+**Known UX quirk:** card may show default mode (e.g. OFF) while `action` is HEATING. Honest > pretty; optional follow-up can map call inputs to a read-only display mode.
+
+### 9.4 Helper placement
+
+Prefer small hub helpers used by climate:
+
+```cpp
+float get_climate_current_temperature_f() const;  // ambient if AWL tstat else EAT
+bool has_awl_thermostat_controls() const;
+```
+
+Keep `this->` conventions; no heap; climate stays thin.
+
+---
+
+## 10. Downstream entities (inherit hub)
+
+No special-case YAML required if hub publish/write gates are correct:
+
+| Entity                                          | Non-AWL result                                   |
+| ----------------------------------------------- | ------------------------------------------------ |
+| Sensors `heating_setpoint`, `cooling_setpoint`  | Never get a state (or stay unavailable)          |
+| Text `hvac_mode`, `fan_mode`                    | No AWL-driven updates                            |
+| Sensors humidification/dehumidification targets | No updates without `has_humidistat_targets()`    |
+| Numbers humidification/dehumidification         | `update_state_` sees NAN; `control` fails at hub |
+| Numbers fan intermittent on/off (system)        | Cache miss without `FAN_CONFIG`                  |
+| Humidistat selects                              | Mode cache not updated; `control` fails at hub   |
+| Binary humidifier/dehumidifier running          | Still work when DIP/hardware says so             |
+
+---
+
+## 11. Detection / config logging
+
+In setup complete / `dump_config` style logs, make capability obvious:
+
+```text
+Tstat: v0.00 installed=no awl_thermostat=no
+AWL communicating: no (thermostat=no iz2=no)
+Humidistat targets: no (need AWL + humidifier/dehumidifier/VS)
+```
+
+(Exact wording flexible; must include enough to debug another daviss57-style report.)
+
+---
+
+## 12. Testing
+
+### 12.1 Unit tests (`tests/test_hub.cpp` and/or focused cases)
+
+Simulate detection outcome without full UART where possible (set flags / drive setup fixtures):
+
+1. **Non-AWL thermostat (version 0, not installed or installed+v0):**
+   - `awl_thermostat() == false`
+   - After a fake publish cycle with garbage 745=1260, 746=600, targets=0xFFFF:  
+     `get_heating_setpoint()` / `get_cooling_setpoint()` are NAN
+   - `set_heating_setpoint(70)` / `set_hvac_mode(...)` / `set_humidification_target(40)` return **false** and do not enqueue writes
+
+2. **AWL thermostat (installed + version ≥ 3.00):**
+   - Valid setpoints publish
+   - Out-of-range 126 °F heating → NAN / not published
+   - Writes still range-checked
+
+3. **`has_humidistat_targets`:**
+   - AWL + no hum/dehum/VS → false (no target poll side effects if testable)
+   - AWL + humidifier → true
+   - non-AWL + humidifier → false
+
+4. **Ambient fallback helper:**
+   - non-AWL + ambient NAN + EAT 74.0 → climate temp source 74.0
+   - AWL + ambient 72 → 72 even if EAT differs
+
+5. **`awl_thermostat` installed bit:** version 3.00 but `THERMOSTAT_INSTALLED == 3` → false
+
+Climate math tests stay as-is; hub/climate integration tests only where the test harness already drives climate.
+
+### 12.2 Manual / field
+
+- daviss57-class dry-contact: no 126/60/255; action + current temp still populate.
+- AWL thermostat install: regression — setpoints/mode/fan/humidity still work.
+
+---
+
+## 13. Documentation
+
+- `docs/ENTITIES.md` — short **Dry-contact / non-AWL** subsection under Climate: status-only targets, writes ignored, needs IntelliZone or communicating thermostat for full control.
+- `README.md` — one bullet if climate features are listed.
+- Issue text can link this spec.
+
+---
+
+## 14. Implementation sketch (file touch list)
+
+| File                                    | Change                                                                        |
+| --------------------------------------- | ----------------------------------------------------------------------------- |
+| `waterfurnace_aurora.h`                 | `has_thermostat_`; fix `awl_thermostat()`; helpers; maybe climate temp helper |
+| `waterfurnace_aurora.cpp`               | Detection store; poll gates; publish gates + sanitizers; write gates; logs    |
+| `climate/aurora_climate.cpp`            | Branch non-IZ2 update on `awl_thermostat()`; EAT fallback; NAN targets        |
+| `climate/aurora_climate_utils.h`        | Humidity read already NAN-safe; ensure no 255 publish                         |
+| `number/aurora_number.cpp`              | Optional early-out if desired; hub gate sufficient                            |
+| `select/aurora_humidistat_select.cpp`   | Optional; hub gate sufficient                                                 |
+| `tests/test_hub.cpp`                    | New sections above                                                            |
+| `docs/ENTITIES.md` (+ README if needed) | User-facing note                                                              |
+
+No protocol/register address changes.
+
+---
+
+## 15. Rollout / risk
+
+| Risk                                                        | Mitigation                                    |
+| ----------------------------------------------------------- | --------------------------------------------- |
+| AWL user with odd firmware version &lt; 3.0 loses setpoints | Matches gem; version threshold is intentional |
+| `has_thermostat_` false negative if reg 800 unread          | Already in detection address list             |
+| Climate mode OFF + action HEATING looks odd                 | Documented; better than fake setpoints        |
+| EAT used as room temp is return-air not zone temp           | Best available without AWL ambient; document  |
+| Write reject surprises automations on dry-contact           | WARN log; correct behavior                    |
+
+---
+
+## 16. Open follow-ups (explicitly out of this spec)
+
+1. Read-only climate `mode` derived from Y1/Y2/O inputs (gem `Thermostat#current_mode`).
+2. Dynamic traits / disable climate controls in HA when non-AWL.
+3. HA `available` flag on setpoint numbers when non-AWL.
+4. Full virtual thermostat / equipment call control from ESPHome.
+
+---
+
+## 17. Acceptance criteria
+
+- [ ] Dry-contact fixture: no heating/cooling setpoint sensor state from garbage regs; climate targets NAN; humidity target not 255
+- [ ] Dry-contact: `set_*` thermostat/humidistat target APIs return false; no write frames queued
+- [ ] Dry-contact: climate `action` still tracks equipment; `current_temperature` from EAT when ambient gated off
+- [ ] AWL thermostat fixture: setpoints, mode, fan, humidity targets still poll/publish/write
+- [ ] `awl_thermostat()` requires installed + version ≥ 3.0
+- [ ] `cd tests && make test` green
+- [ ] ENTITIES/README note present
+
+---
+
+## 18. Decision record
+
+| #   | Topic               | Choice                                                          |
+| --- | ------------------- | --------------------------------------------------------------- |
+| 1   | Scope               | **A** Hub-wide gating                                           |
+| 2   | Climate UX          | **A** Status-oriented (action + current temp; no bogus targets) |
+| 3   | Writes without AWL  | **A** Reject all AWL thermostat + humidistat-target writes      |
+| 4   | Ambient without AWL | **B** Gate 502; climate current temp falls back to entering air |
+| —   | Gem reference       | `../waterfurnace_aurora` v1.6.4 re-verified 2026-07-24          |

--- a/docs/superpowers/specs/2026-07-24-register-debug-access-design.md
+++ b/docs/superpowers/specs/2026-07-24-register-debug-access-design.md
@@ -1,0 +1,561 @@
+# Register Debug Access — Design Spec
+
+**Date:** 2026-07-24  
+**Status:** Draft (awaiting implementation plan)  
+**Related:** GitHub issue #30 (open-loop field validation), closed-loop “Pump Type: Other” investigation  
+**Implements surfaces:** HA service, result text sensor, Web UI entity pattern, opt-in HTTP last-result API
+
+---
+
+## 1. Problem
+
+Field and maintainer debugging often needs a **one-shot read of an arbitrary Aurora register** without:
+
+- Adding that register to the permanent poll set, or
+- Flashing a special build, or
+- Guessing from mapped entities alone
+
+Concrete cases:
+
+| Case | Need |
+|------|------|
+| Pump Type shows `Other` | Raw value of register **413** |
+| Open-loop modulating output (#30) | Raw **321–325** before/without relying only on HA entities |
+| Mystery NA / wrong scaling | Peek related regs while system is live |
+
+### Current state
+
+| Capability | Status |
+|------------|--------|
+| HA `write_register` service | Exists (`USE_API_CUSTOM_SERVICES`) |
+| HA `read_register` service | **Missing** (docs that claim it exists are wrong) |
+| Web UI register peek | **Missing** |
+| HTTP register peek | **Missing** |
+| One-shot read in hub state machine | **Missing** (only periodic poll + setup reads) |
+
+---
+
+## 2. Goals
+
+1. **Read any single register (0–65535)** on demand via safe, async hub API.
+2. Expose that capability through **four complementary surfaces** (phases below).
+3. Always emit a clear **log line** on completion or failure.
+4. Optionally show the last result in **HA / ESPHome Web UI** via a text sensor.
+5. Preserve hub invariants: **no blocking UART in `loop()`**, no heap growth after setup, no `std::deque`, fixed-size pending state.
+6. Default-safe: HTTP debug **off** unless explicitly enabled; **no HTTP write**.
+
+## 3. Non-goals
+
+- Replacing normal polled sensors / entity model
+- Full address-space scan or continuous register streaming (future)
+- HTTP or unauthenticated remote **write**
+- Changing pump-type gating or open-loop poll policy (#30)
+- Returning register values **inline** as HA service call results (HA custom services are fire-and-forget from the device’s perspective; use log + text sensor)
+
+---
+
+## 4. Shared core architecture
+
+All surfaces call the same hub entry point.
+
+```
+  Surface 1: HA read_register(address)
+  Surface 3: button / select / number → lambda
+  Surface 4: HTTP queue + last-result GET
+           │
+           ▼
+  bool request_debug_read(uint16_t addr)
+           │  validate, rate-limit, single pending slot
+           ▼
+  Hub state machine performs one-shot FC3-style read
+  (same framing as normal polls; one address)
+           │
+           ├── success → cache optional touch, format result,
+           │             ESP_LOGI, publish text sensor (if any)
+           └── fail    → ESP_LOGW, publish error string (if any)
+```
+
+### 4.1 Hub API
+
+```cpp
+/// Queue a one-shot read of a single register for debugging.
+/// Returns false if address invalid, rate-limited, already pending, or hub not ready.
+bool request_debug_read(uint16_t addr);
+```
+
+Internal state (fixed-size, no heap):
+
+| Field | Purpose |
+|-------|---------|
+| `debug_read_pending_` | True while a debug read is queued or in flight |
+| `debug_read_addr_` | Address requested |
+| `debug_read_last_ms_` | For rate limiting |
+| `debug_read_last_ok_` | Last completion success flag |
+| `debug_read_last_addr_` | Last completed address |
+| `debug_read_last_value_` | Last completed raw `uint16_t` (valid if ok) |
+| `debug_read_last_error_` | Short static reason if !ok (`"timeout"`, `"busy"`, …) |
+
+Optional: `text_sensor::TextSensor *debug_register_result_sensor_`
+
+### 4.2 Scheduling rules
+
+1. **Ready gate:** Reject (or defer—implementation choice: **reject with log** is simpler) if setup state machine has not finished hardware detection / first IDLE.
+2. **Single slot:** If `debug_read_pending_`, return `false` and log once at WARN.
+3. **Rate limit:** Minimum **500 ms** between accepted debug reads (constant `DEBUG_READ_COOLDOWN_MS`).
+4. **Priority:** Debug read is lower priority than user **writes** already in `pending_writes_`, but may run at next IDLE poll opportunity (implementation: insert as a one-address poll burst or a dedicated state `DEBUG_READ_WAIT` after current transaction completes).
+5. **Timeout:** Same response timeout as normal polls; on timeout clear pending and publish failure.
+6. **No permanent poll change:** Debug read must **not** add the address to fast/medium/slow poll lists.
+
+### 4.3 Result formatting
+
+Log (success):
+
+```text
+[I][waterfurnace_aurora]: debug read: address=413 value=3 (0x0003)
+```
+
+Log (failure):
+
+```text
+[W][waterfurnace_aurora]: debug read: address=413 failed: timeout
+```
+
+Text sensor state (success):
+
+```text
+413 = 3 (0x0003)
+```
+
+Text sensor state (failure):
+
+```text
+413 = timeout
+```
+
+Keep strings short (ESPHome state size / mobile UI). Do **not** embed multi-line dumps.
+
+### 4.4 Security / safety
+
+- Reads are relatively safe; still rate-limit to avoid bus saturation.
+- Do not expose writes on HTTP.
+- Existing HA `write_register` remains the only intentional raw write path and already requires API + custom services.
+- HTTP surface requires explicit YAML opt-in **and** inherits `web_server` auth when configured.
+
+---
+
+## 5. Surface 1 — HA API `read_register` service (Phase 1)
+
+### Behavior
+
+Under `#ifdef USE_API_CUSTOM_SERVICES`, register alongside `write_register`:
+
+```cpp
+register_service(&WaterFurnaceAurora::on_read_register_service_, "read_register",
+                 {"address"});
+```
+
+Handler:
+
+1. Validate `address` ∈ [0, 65535].
+2. Call `request_debug_read(static_cast<uint16_t>(address))`.
+3. Log acceptance or rejection immediately (`queued` vs `rejected: busy`).
+
+### HA usage
+
+```yaml
+# Requires api with custom services enabled (same as write_register today)
+service: esphome.<node_name>_read_register
+data:
+  address: 413
+```
+
+### Docs fix
+
+`DEVELOPMENT.md` currently documents only `write_register`. Update to document `read_register` and remove any implication that read already existed.
+
+### Acceptance
+
+- [ ] Service appears when custom services compiled in  
+- [ ] Calling with 413 produces success or failure log within one response timeout  
+- [ ] Invalid address rejected without bus traffic  
+- [ ] Rapid double-call: second rejected by pending/rate-limit  
+
+---
+
+## 6. Surface 2 — Last-result text sensor (Phase 2)
+
+### Entity
+
+Prefer consistency with other hub text sensors:
+
+```yaml
+text_sensor:
+  - platform: waterfurnace_aurora
+    aurora_id: aurora
+    debug_register_result:
+      name: "Debug Register Result"
+```
+
+### Behavior
+
+- Unpublished / empty until first debug read completes (success or fail).
+- Publish-on-change (same dedup pattern as other text sensors).
+- Updated only from debug-read completion path (not from normal polls).
+
+### Acceptance
+
+- [ ] After HA `read_register`, sensor shows `413 = …`  
+- [ ] Failure path updates sensor with error token  
+- [ ] Entity optional: omitting it does not break Surface 1  
+
+---
+
+## 7. Surface 3 — Web UI via entities (Phase 3)
+
+No custom HTML. Use stock ESPHome Web UI controls + hub API.
+
+### Recommended YAML pattern (document in DEVELOPMENT.md / optional package comments)
+
+```yaml
+number:
+  - platform: template
+    name: "Debug Register Address"
+    id: dbg_reg_addr
+    min_value: 0
+    max_value: 65535
+    step: 1
+    optimistic: true
+    initial_value: 413
+    mode: box
+
+select:
+  - platform: template
+    name: "Debug Register Preset"
+    id: dbg_reg_preset
+    optimistic: true
+    options:
+      - "Pump Type (413)"
+      - "VS Pump Min (321)"
+      - "VS Pump Max (322)"
+      - "VS Pump Manual (323)"
+      - "VS Pump Speed (325)"
+      - "Loop Pressure (1119)"
+    initial_option: "Pump Type (413)"
+    on_value:
+      - lambda: |-
+          // Map label → address; set dbg_reg_addr
+          // (exact mapping table in implementation plan)
+
+button:
+  - platform: template
+    name: "Read Debug Register"
+    on_press:
+      - lambda: |-
+          id(aurora).request_debug_read(
+              static_cast<uint16_t>(id(dbg_reg_addr).state));
+
+text_sensor:
+  - platform: waterfurnace_aurora
+    aurora_id: aurora
+    debug_register_result:
+      name: "Debug Register Result"
+```
+
+### UX notes
+
+| Control | Role |
+|---------|------|
+| Number (`mode: box`) | Freeform address |
+| Select presets | Fast path for common regs |
+| Button | Trigger read |
+| Text sensor | Result on Web UI + HA |
+| Device logs | Same result via `ESP_LOG*` |
+
+Preset list is **documentation + example**, not exhaustive. Users may extend locally.
+
+### Acceptance
+
+- [ ] Documented snippet works with Web UI enabled  
+- [ ] Preset changes address number  
+- [ ] Button triggers same path as HA service  
+- [ ] Result visible without attaching a serial log (via text sensor)  
+
+---
+
+## 8. Surface 4 — Opt-in HTTP last-result API (Phase 4)
+
+**Model C (chosen):** simple curl discovery via **last completed result**, plus an explicit **queue** action. No long-wait inside the HTTP handler.
+
+### Enablement
+
+```yaml
+waterfurnace_aurora:
+  # ...
+  debug_http: true   # default false
+```
+
+Requirements:
+
+- `web_server` component present  
+- `debug_http: true`  
+- Handlers registered with normal web_server auth (`add_handler`, not `add_handler_without_auth`)
+
+If `debug_http: true` without `web_server`, codegen/validation should **fail clearly** at config time.
+
+### Endpoints
+
+#### 8.1 Get last result (primary curl UX)
+
+```http
+GET /aurora/register
+```
+
+Response `200 application/json`:
+
+```json
+{
+  "ok": true,
+  "pending": false,
+  "address": 413,
+  "value": 3,
+  "hex": "0x0003",
+  "error": null,
+  "age_ms": 1204
+}
+```
+
+If never completed:
+
+```json
+{
+  "ok": false,
+  "pending": false,
+  "address": null,
+  "value": null,
+  "hex": null,
+  "error": "no_result_yet",
+  "age_ms": null
+}
+```
+
+If a read is in flight:
+
+```json
+{
+  "ok": false,
+  "pending": true,
+  "address": 413,
+  "value": null,
+  "hex": null,
+  "error": null,
+  "age_ms": null
+}
+```
+
+(`ok` refers to **last completed** read success when `pending` is false and a result exists.)
+
+#### 8.2 Queue a read
+
+```http
+GET /aurora/register?addr=413
+```
+
+or (equivalent, preferred for clarity in docs):
+
+```http
+GET /aurora/register?addr=413&queue=1
+```
+
+Behavior:
+
+1. Validate `addr`.  
+2. Call `request_debug_read(addr)`.  
+3. **Immediately** return JSON snapshot of **current** last-result + pending flag — **do not wait** for the bus.
+
+Example just after queue accepted:
+
+```json
+{
+  "ok": false,
+  "pending": true,
+  "queued": true,
+  "address": 413,
+  "value": null,
+  "hex": null,
+  "error": null,
+  "age_ms": null
+}
+```
+
+If queue rejected:
+
+```json
+{
+  "ok": false,
+  "pending": true,
+  "queued": false,
+  "reject_reason": "rate_limited",
+  "address": 413,
+  "value": null,
+  "hex": null,
+  "error": null,
+  "age_ms": null
+}
+```
+
+#### 8.3 Typical curl discovery flow
+
+```bash
+# 1) Queue
+curl -s 'http://waterfurnace-aurora.local/aurora/register?addr=413'
+
+# 2) Wait ~1s for bus
+
+# 3) Read last result
+curl -s 'http://waterfurnace-aurora.local/aurora/register'
+```
+
+Optional convenience (implementation may add later, not required for v1):
+
+```http
+GET /aurora/register?addr=413&wait_ms=500
+```
+
+**Out of scope for v1** — would approach model B. Spec leaves room but does not require it.
+
+### Explicitly out of scope (HTTP)
+
+- `POST` / `PUT` write  
+- Bulk multi-register dump  
+- WebSocket push of results  
+
+### Acceptance
+
+- [ ] Default build: no `/aurora/register` route  
+- [ ] `debug_http: true` + web_server: both GET forms work  
+- [ ] Auth honored when web_server auth configured  
+- [ ] Handler never blocks on UART  
+
+---
+
+## 9. Phasing and dependencies
+
+| Phase | Deliverable | Depends on |
+|-------|-------------|------------|
+| **P1** | `request_debug_read` + logs + HA `read_register` | — |
+| **P2** | `debug_register_result` text sensor | P1 |
+| **P3** | Documented Web UI YAML (number/select/button) | P1 + P2 |
+| **P4** | Opt-in HTTP last-result + queue (model C) | P1 (P2 optional but recommended) |
+
+**Minimum useful ship:** P1 alone unblocks raw 413 / 321–325 from HA logs.  
+**Nice Web UI:** P1–P3.  
+**Scriptable curl:** P4.
+
+Suggested ship strategy: one PR for P1+P2, follow-up PR for P3 docs + P4, **or** single PR with P4 behind default-off flag if small enough.
+
+---
+
+## 10. Configuration summary
+
+| Key | Where | Default | Notes |
+|-----|--------|---------|-------|
+| `api` + custom services | ESPHome | user config | Enables HA read/write services |
+| `debug_register_result` | text_sensor platform | omitted | Surface 2 |
+| `debug_http` | hub YAML | `false` | Surface 4 |
+| Web UI templates | user YAML | omitted | Surface 3 examples in docs |
+
+No Python codegen beyond: hub `debug_http` bool, text sensor key, validation vs `web_server`.
+
+---
+
+## 11. Testing plan
+
+### Unit / hub tests (Catch2)
+
+- `request_debug_read` rejects when pending  
+- Rate limit rejects within cooldown  
+- Successful path formats last_* fields  
+- Failure path sets error token  
+- Does not add address to poll address builder lists  
+
+### Manual / field
+
+1. HA `read_register` 413 on Series 7 closed loop → capture raw value for “Other” investigation.  
+2. HA `read_register` 321–325 on open-loop test branch unit (#30).  
+3. Web UI button path with text sensor visible.  
+4. curl queue + last-result with `debug_http: true`.  
+5. Confirm normal climate/sensor traffic unaffected under repeated debug reads at cooldown.
+
+### Compile
+
+- `tests/waterfurnace-test.yaml` remains green  
+- Optional test fixture YAML snippet with debug entities (can be comments-only if entities need template platform)
+
+---
+
+## 12. Documentation updates (implementation time)
+
+| File | Change |
+|------|--------|
+| `DEVELOPMENT.md` | Document `read_register`; Web UI snippet; HTTP curl flow; fix any “read already exists” wording |
+| `README.md` | Short “Debug / advanced” pointer |
+| `docs/ENTITIES.md` | `debug_register_result` row if shipped as platform entity |
+| This spec | Status → Implemented + link plan/PR when done |
+
+Optional: `docs/DEBUG_REGISTERS.md` how-to if DEVELOPMENT.md grows too large.
+
+---
+
+## 13. Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Debug reads starve normal polls | Single slot + 500 ms cooldown; writes still prioritized |
+| Users confuse number `0%` with real pump regs | Docs: sensors/NA vs debug raw values |
+| HTTP on LAN without auth | Default `debug_http: false`; use web_server auth; read-only |
+| Async confusion (“service returned but no value”) | Docs emphasize log + text sensor; HTTP model C makes pending explicit |
+| Flash size | P4 optional; P1–P2 small |
+
+---
+
+## 14. Future extensions (not in this spec’s acceptance)
+
+- Named register catalog in C++ shared by select presets and HTTP `?name=pump_type`  
+- Multi-register debug read (small list, still one transaction if protocol allows)  
+- `wait_ms` synchronous-ish HTTP helper  
+- Integration with issue templates (“paste debug read of 413”)
+
+---
+
+## 15. Decision log
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| HA read service | Yes (P1) | Matches existing `write_register` |
+| Result visibility | Log + optional text sensor | HA services don’t return values cleanly |
+| Web UI | Entity pattern, not custom HTML | Stock Web UI, low maintenance |
+| HTTP model | **C** — last result + queue | Simple curl discovery; no handler stall on bus |
+| HTTP write | No | Writes already dangerous enough via HA |
+| Default HTTP | Off | Least surprise / smaller attack surface |
+
+---
+
+## 16. Self-review checklist
+
+- [x] No “TBD” placeholders for required behavior  
+- [x] Phases ordered with clear dependencies  
+- [x] Async bus constraints explicit  
+- [x] HTTP model C specified with example JSON and curl flow  
+- [x] Out of scope listed  
+- [x] Ties to real field needs (#30, Pump Type Other / reg 413)  
+- [x] ESPHome embedded constraints respected (fixed state, no blocking loop)  
+
+---
+
+## 17. Next step
+
+After human approval of this spec file:
+
+1. Run **writing-plans** → `docs/superpowers/plans/YYYY-MM-DD-register-debug-access.md`  
+2. Implement P1→P2 first on a dedicated branch (not mixed with #30 open-loop field-test branch unless intentionally combined)  
+)

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -1721,3 +1721,164 @@ TEST_CASE("Allow humidistat target writes when AWL + humidifier", "[hub][awl][wr
   // Target writes share one register address; mode writes share another — queue coalesces to 2.
   REQUIRE(hub.pending_writes() == 2);
 }
+
+
+TEST_CASE("Non-AWL publish ignores garbage setpoints; EAT climate fallback", "[hub][awl][publish]") {
+  WaterFurnaceAurora hub;
+  sensor::Sensor heat_sp;
+  sensor::Sensor cool_sp;
+  hub.set_heating_setpoint_sensor(&heat_sp);
+  hub.set_cooling_setpoint_sensor(&cool_sp);
+
+  set_millis(0);
+  drive_setup_thermostat(hub, COMPONENT_NOT_INSTALLED, 0);
+  REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+
+  set_millis(200);
+  hub.update();
+  auto tx = hub.mock_get_transmitted();
+  REQUIRE(tx.size() > 0);
+
+  // Non-AWL must not poll thermostat setpoint/mode/ambient/fan regs
+  std::set<uint16_t> addrs;
+  size_t num_regs = (tx.size() - 4) / 2;
+  for (size_t i = 0; i < num_regs; i++) {
+    uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+    addrs.insert(addr);
+  }
+  REQUIRE(addrs.count(registers::HEATING_SETPOINT) == 0);
+  REQUIRE(addrs.count(registers::COOLING_SETPOINT) == 0);
+  REQUIRE(addrs.count(registers::AMBIENT_TEMP) == 0);
+  REQUIRE(addrs.count(registers::HEATING_MODE_READ) == 0);
+  REQUIRE(addrs.count(registers::FAN_CONFIG) == 0);
+  REQUIRE(addrs.count(registers::ENTERING_AIR) == 1);
+
+  complete_tx(hub, 200);
+  std::vector<std::pair<uint16_t, uint16_t>> resp_vals;
+  for (size_t i = 0; i < num_regs; i++) {
+    uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+    uint16_t val = 0;
+    if (addr == registers::ENTERING_AIR) val = 740;  // 74.0 F
+    // Even if somehow present, garbage should not stick — include in map only if polled
+    if (addr == registers::HEATING_SETPOINT) val = 1260;
+    if (addr == registers::COOLING_SETPOINT) val = 600;
+    resp_vals.emplace_back(addr, val);
+  }
+  hub.mock_receive(make_response_42(resp_vals));
+  set_millis(250);
+  hub.loop();
+
+  REQUIRE(std::isnan(hub.get_heating_setpoint()));
+  REQUIRE(std::isnan(hub.get_cooling_setpoint()));
+  REQUIRE(std::isnan(hub.get_ambient_temperature()));
+  REQUIRE(hub.get_entering_air_temperature() == Catch::Approx(74.0f));
+  REQUIRE(hub.get_climate_current_temperature_f() == Catch::Approx(74.0f));
+  REQUIRE_FALSE(heat_sp.has_state_);
+  REQUIRE_FALSE(cool_sp.has_state_);
+}
+
+TEST_CASE("AWL publish accepts valid setpoints and rejects out-of-range", "[hub][awl][publish]") {
+  WaterFurnaceAurora hub;
+  set_millis(0);
+  drive_setup_thermostat(hub, 1, 300);
+  REQUIRE(hub.has_awl_thermostat_controls());
+
+  auto run_poll = [&](uint16_t heat_raw, uint16_t cool_raw, uint16_t ambient_raw, uint32_t t) {
+    set_millis(t);
+    hub.update();
+    auto tx = hub.mock_get_transmitted();
+    REQUIRE(tx.size() > 0);
+    complete_tx(hub, t);
+    size_t num_regs = (tx.size() - 4) / 2;
+    std::vector<std::pair<uint16_t, uint16_t>> resp_vals;
+    for (size_t i = 0; i < num_regs; i++) {
+      uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+      uint16_t val = 0;
+      if (addr == registers::HEATING_SETPOINT) val = heat_raw;
+      if (addr == registers::COOLING_SETPOINT) val = cool_raw;
+      if (addr == registers::AMBIENT_TEMP) val = ambient_raw;
+      if (addr == registers::ENTERING_AIR) val = 800;  // 80 F EAT differs from ambient
+      resp_vals.emplace_back(addr, val);
+    }
+    hub.mock_receive(make_response_42(resp_vals));
+    set_millis(t + 50);
+    hub.loop();
+  };
+
+  SECTION("valid setpoints and ambient preferred over EAT") {
+    run_poll(700, 740, 720, 200);  // 70, 74, 72 F
+    REQUIRE(hub.get_heating_setpoint() == Catch::Approx(70.0f));
+    REQUIRE(hub.get_cooling_setpoint() == Catch::Approx(74.0f));
+    REQUIRE(hub.get_ambient_temperature() == Catch::Approx(72.0f));
+    REQUIRE(hub.get_climate_current_temperature_f() == Catch::Approx(72.0f));
+  }
+
+  SECTION("out-of-range heating forces NAN") {
+    run_poll(700, 740, 720, 200);
+    REQUIRE(hub.get_heating_setpoint() == Catch::Approx(70.0f));
+    run_poll(1260, 740, 720, 400);  // 126 F garbage
+    REQUIRE(std::isnan(hub.get_heating_setpoint()));
+    REQUIRE(hub.get_cooling_setpoint() == Catch::Approx(74.0f));
+  }
+}
+
+TEST_CASE("Humidistat targets not polled without has_humidistat_targets", "[hub][awl][publish]") {
+  WaterFurnaceAurora hub;
+  set_millis(0);
+  drive_setup_thermostat(hub, 1, 300, false);  // AWL, no humidifier
+  REQUIRE(hub.has_awl_thermostat_controls());
+  REQUIRE_FALSE(hub.has_humidistat_targets());
+
+  // Medium tier every 6th cycle — advance poll counter by calling update multiple times
+  // with responses so tier advances. Simpler: request one poll at time where medium applies.
+  // poll_tier_counter_ % 6 == 0 on first update after setup.
+  set_millis(200);
+  hub.update();
+  auto tx = hub.mock_get_transmitted();
+  std::set<uint16_t> addrs;
+  size_t num_regs = (tx.size() - 4) / 2;
+  for (size_t i = 0; i < num_regs; i++) {
+    uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+    addrs.insert(addr);
+  }
+  // First poll may or may not be medium tier. Force medium by draining several cycles.
+  complete_tx(hub, 200);
+  // Feed empty zeros for all requested
+  std::vector<std::pair<uint16_t, uint16_t>> resp;
+  for (size_t i = 0; i < num_regs; i++) {
+    uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+    resp.emplace_back(addr, 0);
+  }
+  hub.mock_receive(make_response_42(resp));
+  set_millis(250);
+  hub.loop();
+
+  // Run 6 more full poll cycles to hit medium tier with certainty
+  bool saw_medium_without_humidistat = false;
+  for (int cycle = 0; cycle < 8; cycle++) {
+    uint32_t t = 300 + cycle * 100;
+    set_millis(t);
+    hub.update();
+    tx = hub.mock_get_transmitted();
+    if (tx.empty()) continue;
+    complete_tx(hub, t);
+    num_regs = (tx.size() - 4) / 2;
+    addrs.clear();
+    resp.clear();
+    for (size_t i = 0; i < num_regs; i++) {
+      uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+      addrs.insert(addr);
+      resp.emplace_back(addr, 0);
+    }
+    if (addrs.count(registers::LAST_LOCKOUT_FAULT)) {
+      // medium tier
+      REQUIRE(addrs.count(registers::HUMIDISTAT_TARGETS) == 0);
+      REQUIRE(addrs.count(registers::HUMIDISTAT_SETTINGS) == 0);
+      saw_medium_without_humidistat = true;
+    }
+    hub.mock_receive(make_response_42(resp));
+    set_millis(t + 50);
+    hub.loop();
+  }
+  REQUIRE(saw_medium_without_humidistat);
+}

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -14,6 +14,7 @@ struct TestableHub : public WaterFurnaceAurora {
   State get_state() const { return this->state_; }
   bool get_dealer_info_read() const { return this->dealer_info_read_; }
   size_t get_response_frame_len() const { return this->response_frame_len_; }
+  size_t pending_writes() const { return this->pending_writes_len_; }
 };
 
 // Helper kept for call-site readability after a send.
@@ -25,6 +26,10 @@ static void complete_tx(WaterFurnaceAurora &hub, uint32_t current_ms) {
   set_millis(current_ms + 1);
   hub.loop();  // already WAITING_RESPONSE — may collect any already-queued RX
 }
+
+static void drive_setup(WaterFurnaceAurora &hub);
+static void drive_setup_thermostat(WaterFurnaceAurora &hub, uint16_t installed_val,
+                                   uint16_t version_raw, bool humidifier = false);
 
 // Helper: build a valid func 0x42 response frame from address-value pairs
 static std::vector<uint8_t> make_response_42(const std::vector<std::pair<uint16_t, uint16_t>> &regs) {
@@ -81,6 +86,9 @@ static std::vector<uint8_t> make_response_03(const std::vector<uint16_t> &values
 
 TEST_CASE("Write queue", "[hub][write]") {
   WaterFurnaceAurora hub;
+  // AWL + humidifier so range-validation sections exercise post-capability checks
+  set_millis(0);
+  drive_setup_thermostat(hub, 1, 300, true);
   set_millis(1000);
 
   SECTION("write_register queues a single write") {
@@ -158,13 +166,13 @@ TEST_CASE("Write queue", "[hub][write]") {
     REQUIRE(hub.set_dehumidification_target(50));         // Valid
   }
 
-  SECTION("set_hvac_mode always succeeds") {
+  SECTION("set_hvac_mode succeeds when AWL") {
     REQUIRE(hub.set_hvac_mode(HeatingMode::HEAT));
     REQUIRE(hub.set_hvac_mode(HeatingMode::COOL));
     REQUIRE(hub.set_hvac_mode(HeatingMode::OFF));
   }
 
-  SECTION("set_fan_mode always succeeds") {
+  SECTION("set_fan_mode succeeds when AWL") {
     REQUIRE(hub.set_fan_mode(FanMode::AUTO));
     REQUIRE(hub.set_fan_mode(FanMode::CONTINUOUS));
   }
@@ -480,8 +488,6 @@ TEST_CASE("RS-485 resync drops leading noise before slave address", "[hub][state
   REQUIRE(tx[1] == 0x42);
 }
 
-static void drive_setup(WaterFurnaceAurora &hub);
-
 TEST_CASE("fault history timeout chains to dealer info read", "[hub][state][chain]") {
   TestableHub hub;
   text_sensor::TextSensor fault_history;
@@ -587,7 +593,7 @@ static void drive_setup(WaterFurnaceAurora &hub) {
 /// version_raw: register 801 units (300 = v3.00).
 /// humidifier: DIP accessory_relay = HUMIDIFIER (bits 3-4 = 2 → raw 0x10).
 static void drive_setup_thermostat(WaterFurnaceAurora &hub, uint16_t installed_val,
-                                   uint16_t version_raw, bool humidifier = false) {
+                                   uint16_t version_raw, bool humidifier) {
   hub.setup();
 
   hub.loop();
@@ -1659,4 +1665,59 @@ TEST_CASE("has_humidistat_targets matches gem", "[hub][awl][humidistat]") {
     REQUIRE_FALSE(hub.has_awl_thermostat_controls());
     REQUIRE_FALSE(hub.has_humidistat_targets());
   }
+}
+
+
+TEST_CASE("Reject thermostat writes without AWL thermostat", "[hub][awl][write]") {
+  TestableHub hub;
+  set_millis(0);
+  drive_setup_thermostat(hub, COMPONENT_NOT_INSTALLED, 0);
+  REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+  REQUIRE(hub.pending_writes() == 0);
+
+  REQUIRE_FALSE(hub.set_heating_setpoint(70.0f));
+  REQUIRE_FALSE(hub.set_cooling_setpoint(74.0f));
+  REQUIRE_FALSE(hub.set_hvac_mode(HeatingMode::HEAT));
+  REQUIRE_FALSE(hub.set_fan_mode(FanMode::AUTO));
+  REQUIRE_FALSE(hub.set_fan_intermittent_on(5));
+  REQUIRE_FALSE(hub.set_fan_intermittent_off(10));
+  REQUIRE_FALSE(hub.set_humidification_target(40));
+  REQUIRE_FALSE(hub.set_dehumidification_target(50));
+  REQUIRE_FALSE(hub.set_humidifier_mode(true));
+  REQUIRE_FALSE(hub.set_dehumidifier_mode(true));
+
+  REQUIRE(hub.pending_writes() == 0);
+}
+
+TEST_CASE("Allow thermostat writes with AWL thermostat", "[hub][awl][write]") {
+  TestableHub hub;
+  set_millis(0);
+  drive_setup_thermostat(hub, 1, 300);
+  REQUIRE(hub.has_awl_thermostat_controls());
+  REQUIRE(hub.pending_writes() == 0);
+
+  REQUIRE(hub.set_heating_setpoint(70.0f));
+  REQUIRE(hub.set_cooling_setpoint(74.0f));
+  REQUIRE(hub.set_hvac_mode(HeatingMode::HEAT));
+  REQUIRE(hub.set_fan_mode(FanMode::CONTINUOUS));
+  REQUIRE(hub.pending_writes() == 4);
+
+  // Humidistat targets still require AWL + humidifier/dehumidifier/VS
+  REQUIRE_FALSE(hub.has_humidistat_targets());
+  size_t before = hub.pending_writes();
+  REQUIRE_FALSE(hub.set_humidification_target(40));
+  REQUIRE(hub.pending_writes() == before);
+}
+
+TEST_CASE("Allow humidistat target writes when AWL + humidifier", "[hub][awl][write]") {
+  TestableHub hub;
+  set_millis(0);
+  drive_setup_thermostat(hub, 1, 300, true);
+  REQUIRE(hub.has_humidistat_targets());
+  REQUIRE(hub.set_humidification_target(40));
+  REQUIRE(hub.set_dehumidification_target(50));
+  REQUIRE(hub.set_humidifier_mode(true));
+  REQUIRE(hub.set_dehumidifier_mode(false));
+  // Target writes share one register address; mode writes share another — queue coalesces to 2.
+  REQUIRE(hub.pending_writes() == 2);
 }

--- a/tests/test_hub.cpp
+++ b/tests/test_hub.cpp
@@ -558,6 +558,7 @@ static void drive_setup(WaterFurnaceAurora &hub) {
   for (size_t i = 0; i < num_detect_regs; i++) {
     uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
     uint16_t val = 3;
+    if (addr == registers::THERMOSTAT_INSTALLED) val = 1;
     if (addr == registers::THERMOSTAT_VERSION) val = 300;
     if (addr == registers::BLOWER_TYPE) val = 0;
     if (addr == registers::ENERGY_MONITOR) val = 0;
@@ -578,6 +579,54 @@ static void drive_setup(WaterFurnaceAurora &hub) {
   hub.mock_receive(make_response_42({{3001, 0}, {3322, 0}, {3325, 0}}));
   set_millis(150);
   hub.loop();                  // processes VS probe → finish setup → IDLE
+}
+
+
+/// Custom setup with explicit thermostat installed status + version.
+/// installed_val: COMPONENT_NOT_INSTALLED (3) = absent; any other = present (gem).
+/// version_raw: register 801 units (300 = v3.00).
+/// humidifier: DIP accessory_relay = HUMIDIFIER (bits 3-4 = 2 → raw 0x10).
+static void drive_setup_thermostat(WaterFurnaceAurora &hub, uint16_t installed_val,
+                                   uint16_t version_raw, bool humidifier = false) {
+  hub.setup();
+
+  hub.loop();
+  hub.mock_get_transmitted();
+  complete_tx(hub, 0);
+  std::vector<uint16_t> id_values(18, 0x2020);
+  hub.mock_receive(make_response_03(id_values));
+  set_millis(50);
+  hub.loop();
+
+  hub.loop();
+  auto tx = hub.mock_get_transmitted();
+  size_t num_detect_regs = (tx.size() - 4) / 2;
+  std::vector<std::pair<uint16_t, uint16_t>> detect_vals;
+  for (size_t i = 0; i < num_detect_regs; i++) {
+    uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
+    uint16_t val = 3;
+    if (addr == registers::THERMOSTAT_INSTALLED) val = installed_val;
+    if (addr == registers::THERMOSTAT_VERSION) val = version_raw;
+    if (addr == registers::BLOWER_TYPE) val = 0;
+    if (addr == registers::ENERGY_MONITOR) val = 0;
+    if (addr == registers::PUMP_TYPE) val = 0;
+    // accessory_relay HUMIDIFIER = 2 in bits 3-4 → (2 << 3) = 0x10
+    if (addr == registers::DIP_SWITCH_STATUS && humidifier) val = 0x10;
+    if (addr >= 88 && addr <= 91) val = 0x2020;
+    detect_vals.emplace_back(addr, val);
+  }
+  complete_tx(hub, 50);
+  hub.mock_receive(make_response_42(detect_vals));
+  set_millis(100);
+  hub.loop();
+
+  hub.loop();
+  hub.loop();
+  hub.mock_get_transmitted();
+  complete_tx(hub, 100);
+  hub.mock_receive(make_response_42({{3001, 0}, {3322, 0}, {3325, 0}}));
+  set_millis(150);
+  hub.loop();
 }
 
 TEST_CASE("Full setup flow with mock UART", "[hub][state][integration]") {
@@ -617,6 +666,7 @@ TEST_CASE("Full setup flow with mock UART", "[hub][state][integration]") {
   for (size_t i = 0; i < num_detect_regs; i++) {
     uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
     uint16_t val = 3;  // Default = "removed" for component status
+    if (addr == registers::THERMOSTAT_INSTALLED) val = 1;
     if (addr == registers::THERMOSTAT_VERSION) val = 300;
     if (addr == registers::BLOWER_TYPE) val = 0;
     if (addr == registers::ENERGY_MONITOR) val = 0;
@@ -820,6 +870,7 @@ TEST_CASE("Leaving air temperature on non-AWL systems", "[hub][sensors]") {
     for (size_t i = 0; i < num_detect_regs; i++) {
       uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
       uint16_t val = 3;
+      if (addr == registers::THERMOSTAT_INSTALLED) val = 1;
       if (addr == registers::THERMOSTAT_VERSION) val = 300;
       if (addr == registers::AXB_VERSION) val = 200;  // AWL AXB v2.00
       if (addr == registers::BLOWER_TYPE) val = 0;
@@ -1057,6 +1108,7 @@ TEST_CASE("Approach temperature requires compressor running", "[hub][sensors][de
   for (size_t i = 0; i < num_detect_regs; i++) {
     uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
     uint16_t val = 3;
+    if (addr == registers::THERMOSTAT_INSTALLED) val = 1;
     if (addr == registers::THERMOSTAT_VERSION) val = 300;
     if (addr == registers::AXB_VERSION) val = 200;  // AWL AXB v2.00
     if (addr == registers::BLOWER_TYPE) val = 0;
@@ -1183,6 +1235,7 @@ static void drive_setup_with_pump(WaterFurnaceAurora &hub, uint16_t pump_type_va
   for (size_t i = 0; i < num_detect_regs; i++) {
     uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
     uint16_t val = 3;
+    if (addr == registers::THERMOSTAT_INSTALLED) val = 1;
     if (addr == registers::THERMOSTAT_VERSION) val = 300;
     if (addr == registers::AXB_VERSION) val = axb_version_val;
     if (addr == registers::BLOWER_TYPE) val = 0;
@@ -1358,6 +1411,7 @@ TEST_CASE("water_temps_swapped corrects COP heat register", "[hub][swap][cop]") 
   for (size_t i = 0; i < num_detect_regs; i++) {
     uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
     uint16_t val = 3;
+    if (addr == registers::THERMOSTAT_INSTALLED) val = 1;
     if (addr == registers::THERMOSTAT_VERSION) val = 300;
     if (addr == registers::AXB_VERSION) val = 200;
     if (addr == registers::BLOWER_TYPE) val = 0;
@@ -1461,6 +1515,7 @@ TEST_CASE("water_temps_swapped corrects approach temp in cooling", "[hub][swap][
   for (size_t i = 0; i < num_detect_regs; i++) {
     uint16_t addr = (tx[2 + i * 2] << 8) | tx[3 + i * 2];
     uint16_t val = 3;
+    if (addr == registers::THERMOSTAT_INSTALLED) val = 1;
     if (addr == registers::THERMOSTAT_VERSION) val = 300;
     if (addr == registers::AXB_VERSION) val = 200;
     if (addr == registers::BLOWER_TYPE) val = 0;
@@ -1535,5 +1590,73 @@ TEST_CASE("VS Pump manual control state tracking", "[hub][pump]") {
     REQUIRE(hub.is_pump_manual_control());
     REQUIRE(hub.set_pump_manual_control(false));
     REQUIRE_FALSE(hub.is_pump_manual_control());
+  }
+}
+
+
+// ============================================================================
+// AWL thermostat / humidistat capability (gem-compatible)
+// ============================================================================
+
+TEST_CASE("awl_thermostat requires installed and version >= 3.0", "[hub][awl][capability]") {
+  SECTION("version 3.00 but not installed") {
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, COMPONENT_NOT_INSTALLED, 300);
+    REQUIRE(hub.is_setup_complete());
+    REQUIRE_FALSE(hub.has_thermostat());
+    REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+    REQUIRE_FALSE(hub.awl_communicating());
+  }
+
+  SECTION("installed + version 3.00") {
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, 1, 300);
+    REQUIRE(hub.has_thermostat());
+    REQUIRE(hub.has_awl_thermostat_controls());
+    REQUIRE(hub.awl_communicating());
+  }
+
+  SECTION("installed + version 0.00 (dry-contact garbage version)") {
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, 1, 0);
+    REQUIRE(hub.has_thermostat());
+    REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+  }
+
+  SECTION("not installed + version 0") {
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, COMPONENT_NOT_INSTALLED, 0);
+    REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+  }
+}
+
+TEST_CASE("has_humidistat_targets matches gem", "[hub][awl][humidistat]") {
+  SECTION("AWL thermostat without humidifier/dehumidifier/VS") {
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, 1, 300, false);
+    REQUIRE(hub.has_awl_thermostat_controls());
+    REQUIRE_FALSE(hub.has_humidistat_targets());
+  }
+
+  SECTION("AWL thermostat with humidifier") {
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, 1, 300, true);
+    REQUIRE(hub.has_humidifier());
+    REQUIRE(hub.has_humidistat_targets());
+  }
+
+  SECTION("non-AWL with humidifier") {
+    WaterFurnaceAurora hub;
+    set_millis(0);
+    drive_setup_thermostat(hub, COMPONENT_NOT_INSTALLED, 0, true);
+    REQUIRE(hub.has_humidifier());
+    REQUIRE_FALSE(hub.has_awl_thermostat_controls());
+    REQUIRE_FALSE(hub.has_humidistat_targets());
   }
 }


### PR DESCRIPTION
## Summary
- Gate thermostat ambient/setpoints/mode/fan and humidistat targets on hub AWL capability (gem-compatible: installed + version ≥ 3.0)
- Reject misleading writes on dry-contact installs
- Climate status-oriented path with entering-air current temp fallback
- Docs for dry-contact UX

Relates to field report follow-up (GitHub #28 dry-contact targets / daviss57).

## Spec
`docs/superpowers/specs/2026-07-24-non-awl-climate-gating-design.md`
`docs/superpowers/plans/2026-07-24-non-awl-climate-gating.md`

## Test plan
- [x] `cd tests && make test` (352 hub assertions, all suites green)
- [ ] Field: dry-contact unit — no 126/60/255; action + EAT temp
- [ ] Field: AWL thermostat — regression on setpoints/mode/fan/humidity